### PR TITLE
Fix for createTask user API call fails with missing saticChunk parameter

### DIFF
--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -701,7 +701,6 @@ class TaskUtils {
       $cracker->getCrackerBinaryTypeId(),
       $taskWrapper->getId(),
       0,
-      0,
       $isPrince,
       $notes,
       $staticChunking,


### PR DESCRIPTION
User API call to createTask was failing due to mismatch in parameter list.