### PR TITLE
Mask API keys for other users with config setting

### DIFF
--- a/src/account.php
+++ b/src/account.php
@@ -1,8 +1,11 @@
 <?php
 
 use DBA\Factory;
+use DBA\APiKey;
+use DBA\QueryFilter;
 
 require_once(dirname(__FILE__) . "/inc/load.php");
+
 
 if (!Login::getInstance()->isLoggedin()) {
   header("Location: index.php?err=4" . time() . "&fw=" . urlencode($_SERVER['PHP_SELF'] . "?" . $_SERVER['QUERY_STRING']));
@@ -26,6 +29,10 @@ if (isset($_POST['action']) && CSRF::check($_POST['csrf'])) {
 
 $group = Factory::getRightGroupFactory()->get(Login::getInstance()->getUser()->getRightGroupId());
 UI::add('group', $group);
+
+$qF = new QueryFilter(ApiKey::USER_ID, Login::getInstance()->getUserID(), "=");
+$apiKeys = Factory::getApiKeyFactory()->filter([Factory::FILTER=>$qF]);
+UI::add('keys', $apiKeys);
 
 echo Template::getInstance()->render(UI::getObjects());
 

--- a/src/api.php
+++ b/src/api.php
@@ -3,6 +3,7 @@
 use DBA\APiKey;
 use DBA\QueryFilter;
 use DBA\Factory;
+use DBA\User;
 
 require_once(dirname(__FILE__) . "/inc/load.php");
 
@@ -18,10 +19,18 @@ Menu::get()->setActive("users_api");
 
 //catch actions here...
 if (isset($_POST['action']) && CSRF::check($_POST['csrf'])) {
-  $apiHandler = new ApiHandler();
-  $apiHandler->handle($_POST['action']);
-  if (UI::getNumMessages() == 0) {
-    Util::refresh();
+  if($MASK_API_KEYS) {
+    $key = Factory::getApiKeyFactory()->get($_POST['keyId']);
+    if($key->getUserId() != $_POST['userId']){
+      UI::addMessage(UI::ERROR, "Can't change key owner!");
+    }
+  }
+  if(UI::getNumMessages() == 0){
+    $apiHandler = new ApiHandler();
+    $apiHandler->handle($_POST['action']);
+    if (UI::getNumMessages() == 0) {
+      Util::refresh();
+    }
   }
 }
 
@@ -36,7 +45,15 @@ else if (isset($_GET['id'])) {
   }
   else {
     $qF = new QueryFilter(ApiKey::API_GROUP_ID, $group->getId(), "=");
-    UI::add('keys', Factory::getApiKeyFactory()->filter([Factory::FILTER => $qF]));
+    $keys = Factory::getApiKeyFactory()->filter([Factory::FILTER => $qF]);
+    if($MASK_API_KEYS) {
+      $userID = Login::getInstance()->getUserID();
+      foreach ($keys as $key)
+        if($key->getUserId() != $userID) {
+          $key->setAccessKey("******************************");
+        }
+    }
+    UI::add('keys', $keys);
     UI::add('sectionConstants', USection::getConstants());
     
     $section = USection::TEST;
@@ -80,8 +97,19 @@ else if (isset($_GET['keyId'])) {
   if ($key == null) {
     UI::printError(UI::ERROR, "Invalid API key ID!");
   }
+  if ($MASK_API_KEYS) {
+    $userID = Login::getInstance()->getUserID();
+    $qF = new QueryFilter(User::USER_ID, $key->getUserId(), "=");
+    $users = Factory::getUserFactory()->filter([Factory::FILTER=>$qF]);
+    if ($key->getUserId() != $userID) {
+      $key->setAccessKey("******************************");
+    }
+  }
+  else {
+    $users = Factory::getUserFactory()->filter([]);
+  }
   UI::add('key', $key);
-  UI::add('users', Factory::getUserFactory()->filter([]));
+  UI::add('users', $users);
   UI::add('groups', Factory::getApiGroupFactory()->filter([]));
   UI::add('pageTitle', "Edit API key");
   Template::loadInstance("api/key");
@@ -96,11 +124,15 @@ else {
   }
   
   $allApiKeys = Factory::getApiKeyFactory()->filter([]);
+  $userID = Login::getInstance()->getUserID();
   foreach ($allApiKeys as $apiKey) {
     $apis[$apiKey->getApiGroupId()]++;
+    if ($MASK_API_KEYS && $apiKey->getUserId() != $userID) {
+      $apiKey->setAccessKey("******************************");
+    }
   }
   
-  UI::add('keys', Factory::getApiKeyFactory()->filter([]));
+  UI::add('keys', $allApiKeys);
   UI::add('apis', new DataSet($apis));
   UI::add('groups', $groups);
   UI::add('pageTitle', "Api Groups");

--- a/src/api.php
+++ b/src/api.php
@@ -19,12 +19,6 @@ Menu::get()->setActive("users_api");
 
 //catch actions here...
 if (isset($_POST['action']) && CSRF::check($_POST['csrf'])) {
-  if($MASK_API_KEYS) {
-    $key = Factory::getApiKeyFactory()->get($_POST['keyId']);
-    if($key->getUserId() != $_POST['userId']){
-      UI::addMessage(UI::ERROR, "Can't change key owner!");
-    }
-  }
   if(UI::getNumMessages() == 0){
     $apiHandler = new ApiHandler();
     $apiHandler->handle($_POST['action']);

--- a/src/inc/conf.template.php
+++ b/src/inc/conf.template.php
@@ -16,5 +16,4 @@ $PEPPER = [
 
 $INSTALL = false; //set this to true if you config the mysql and setup manually
 
-$MASK_API_KEYS = false; // set this to true to restrict access to API keys to their owners
 //END CONFIG

--- a/src/inc/conf.template.php
+++ b/src/inc/conf.template.php
@@ -15,4 +15,6 @@ $PEPPER = [
 ];
 
 $INSTALL = false; //set this to true if you config the mysql and setup manually
+
+$MASK_API_KEYS = false; // set this to true to restrict access to API keys to their owners
 //END CONFIG

--- a/src/inc/load.php
+++ b/src/inc/load.php
@@ -39,6 +39,8 @@ foreach ($directories as $directory) {
 
 include(dirname(__FILE__) . "/protocol.php");
 
+include(dirname(__FILE__) . "/mask.php");
+
 // include DBA
 require_once(dirname(__FILE__) . "/../dba/init.php");
 

--- a/src/inc/mask.php
+++ b/src/inc/mask.php
@@ -1,0 +1,4 @@
+<?php
+
+$MASK_API_KEYS = true;  // Set this to true to restrict access to API keys to their individual owners.
+                        // This will also deny administrators permission to re-assign API key owners.

--- a/src/inc/utils/ApiUtils.class.php
+++ b/src/inc/utils/ApiUtils.class.php
@@ -62,6 +62,10 @@ class ApiUtils {
     else if ($group == null) {
       throw new HTException("Invalid API group selected!");
     }
+    else if(MASK_API_KEYS && ($key->getUserId() != $userId)){
+      throw new HTException("Can't change key owner!");
+    }
+
     Factory::getApiKeyFactory()->mset($key, [
         ApiKey::USER_ID => $user->getId(),
         ApiKey::API_GROUP_ID => $group->getId(),

--- a/src/templates/account.template.html
+++ b/src/templates/account.template.html
@@ -142,4 +142,22 @@
 	  </table>
   </div>
 </div>
+{{IF [[sizeof([[keys]])]] > 0}}
+	<div class="card">
+		<div class="table-responsive">
+	  		<table class="table table-bordered">
+				<tbody>
+					<tr>
+						<th>API Keys</th>
+						<td>
+							{{FOREACH key;[[keys]]}}
+								[[key.getAccessKey()]]</br>
+							{{ENDFOREACH}}
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+  	</div>
+{{ENDIF}}
 {%TEMPLATE->struct/foot%}


### PR DESCRIPTION
Addressing enhancement #565 this change masks viewing of other user's API keys by administrators. This change also prevents reassignment of API keys between users. 

Set `$MASK_API_KEYS = true` in conf.php to activate the feature.