### PR TITLE
Fixing support for PMKID hashes

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -27,6 +27,7 @@
 - Files can now be selected for either the cracker task or the preprocessor and are filled in the corresponding field.
 - Included new Hashcat modes included in newest beta.
 - Adjusted to new format of Hashcat printing cracked WPA hashes.
+- Adjusted to PMKID handling of Hashcat.
 
 # v0.10.1 -> v0.11.0
 

--- a/src/inc/Util.class.php
+++ b/src/inc/Util.class.php
@@ -836,7 +836,7 @@ class Util {
     );
     $formats = array(
       "Text",
-      "HCCAPX",
+      "HCCAPX / PMKID",
       "Binary",
       "Superhashlist"
     );

--- a/src/inc/api/APISendProgress.class.php
+++ b/src/inc/api/APISendProgress.class.php
@@ -232,22 +232,39 @@ class APISendProgress extends APIBasic {
           }
           break;
         case DHashlistFormat::WPA:
-          // save cracked wpa password
-          // result sent: [a895f7d62ccc3e892fa9e9f9146232c1:]aef50f22801c:987bdcf9f950:8381533406003807685881523	hashcat!	6861736863617421	12
+          // save cracked wpa / pmkid password
+          // possible results:
+          // HCCAPX:        [a895f7d62ccc3e892fa9e9f9146232c1:]aef50f22801c:987bdcf9f950:8381533406003807685881523	hashcat!	6861736863617421	12
+          // PMKID (16800): 4604ba734d4e:89acf0e761f4:$HEX[ed487162465a774bfba60eb603a39f3a]        hashcat!        6861736863617421        31
+          // PMKID (16801): 4604ba734d4e:89acf0e761f4       5b13d4babb3714ccc62c9f71864bc984efd6a55f237c7a87fc2151e1ca658a9-        3562313364346261626233373134636363363263396637313836346263393834656664366135356632333763376138376663323135316531636136353861392d   14
           $split = explode(":", $splitLine[0]);
-          if (sizeof($split) == 4) { // this format was sent up to (and including) release 5.1.0
+          if (sizeof($split) == 4) { // this format was sent up to (and including) release 5.1.0 for -m 2500
             $mac_ap = $split[1];
             $mac_cli = $split[2];
             $essid = $split[3];
           }
-          else { // this format is used in the current state of hashcat
+          else if (sizeof($split) == 3) { // this format is used in the current state of hashcat for -m 2500,16800
             $mac_ap = $split[0];
             $mac_cli = $split[1];
             $essid = $split[2];
           }
+          else { // this format is used for -m 16801
+            $mac_ap = $split[0];
+            $mac_cli = $split[1];
+          }
+          if (Util::startsWith('$HEX[', $essid) && Util::endsWith("]", $essid) && strlen($essid) % 2 == 0) {
+            $essid = substr($essid, 5, strlen($essid) - 6);
+          }
+          else if (sizeof($split) < 4) { // for the new formats, if the SSID is not given in hex, we need to convert it back, as the input is always in hex
+            $essid = Util::strToHex($essid);
+          }
+          $identification = $mac_ap . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . $mac_cli;
+          if (sizeof($split) > 2) {
+            $identification .= SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . $essid;
+          }
           $plain = $splitLine[1];
           $crackPos = $splitLine[3];
-          $qF1 = new QueryFilter(HashBinary::ESSID, $mac_ap . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . $mac_cli . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . $essid, "=");
+          $qF1 = new QueryFilter(HashBinary::ESSID, $identification, "=");
           $qF2 = new QueryFilter(HashBinary::IS_CRACKED, 0, "=");
           $hashes = Factory::getHashBinaryFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
           if (sizeof($hashes) == 0) {

--- a/src/inc/api/APISendProgress.class.php
+++ b/src/inc/api/APISendProgress.class.php
@@ -252,7 +252,7 @@ class APISendProgress extends APIBasic {
             $mac_ap = $split[0];
             $mac_cli = $split[1];
           }
-          if (Util::startsWith('$HEX[', $essid) && Util::endsWith("]", $essid) && strlen($essid) % 2 == 0) {
+          if (Util::startsWith($essid, '$HEX[') && Util::endsWith($essid, "]") && strlen($essid) % 2 == 0) {
             $essid = substr($essid, 5, strlen($essid) - 6);
           }
           else if (sizeof($split) < 4) { // for the new formats, if the SSID is not given in hex, we need to convert it back, as the input is always in hex

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -881,7 +881,7 @@ class HashlistUtils {
               $mac_cli .= $data[$i];
             }
             $mac_cli = Util::bintohex($mac_cli);
-            $hash = new HashBinary(null, $hashlist->getId(), $mac_ap . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . $mac_cli . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . $network, Util::bintohex($data), null, 0, null, 0, 0);
+            $hash = new HashBinary(null, $hashlist->getId(), $mac_ap . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . $mac_cli . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . Util::bintohex($network), Util::bintohex($data), null, 0, null, 0, 0);
             Factory::getHashBinaryFactory()->save($hash);
             $added++;
           }

--- a/src/templates/hashlists/new.template.html
+++ b/src/templates/hashlists/new.template.html
@@ -16,6 +16,7 @@
 	}
 
   var hashtypes = [[allHashtypes]];
+	var activated = false;
 
 	function hashtypeChange(){
     var id = $( "#hashtype" ).val();
@@ -25,8 +26,11 @@
     else{
         $("#salted").prop("checked", false);
     }
-    if(id === 2500 || id === 16800 || id === 16801){
+    if(parseInt(id) === 2500 || parseInt(id) === 16800 || parseInt(id) === 16801){
 			$("#hashlistFormat option[value='1']").prop('selected', true);
+			activated = true;
+		}else if(activated){
+			$("#hashlistFormat option[value='1']").prop('selected', false);
 		}
   }
 </script>

--- a/src/templates/hashlists/new.template.html
+++ b/src/templates/hashlists/new.template.html
@@ -26,7 +26,7 @@
         $("#salted").prop("checked", false);
     }
     if(id === 2500 || id === 16800 || id === 16801){
-    	$('#hashlistFormat').val('1');
+			$("#hashlistFormat option[value='1']").prop('selected', true);
 		}
   }
 </script>

--- a/src/templates/hashlists/new.template.html
+++ b/src/templates/hashlists/new.template.html
@@ -25,6 +25,9 @@
     else{
         $("#salted").prop("checked", false);
     }
+    if(id === 2500 || id === 16800 || id === 16801){
+    	$('#hashlistFormat').val('1');
+		}
   }
 </script>
 <form class='form-inline' action="hashlists.php" method="POST" enctype="multipart/form-data">
@@ -76,9 +79,9 @@
 			<tr>
 				<td>Hashlist format:</td>
 				<td>
-					<select class='form-control' name="format" onChange="formatChange(this.value);" title="Hashlist Format">
+					<select class='form-control' id='hashlistFormat' name="format" onChange="formatChange(this.value);" title="Hashlist Format">
 						<option value="0">Text file</option>
-						<option value="1">HCCAPX file</option>
+						<option value="1">HCCAPX file / PMKID hash</option>
 						<option value="2">Binary file (single hash)</option>
 					</select>
 					<span class="textopt">
@@ -109,7 +112,7 @@
 				<td>
 					<select name="accessGroupId" class="form-control" title="accessGroupId">
 						{{FOREACH accessGroup;[[accessGroups]]}}
-						<option value="[[accessGroup.getId()]]">[[accessGroup.getGroupName()]]</option>
+							<option value="[[accessGroup.getId()]]">[[accessGroup.getGroupName()]]</option>
 						{{ENDFOREACH}}
 					</select>
 				</td>


### PR DESCRIPTION
PMKID hashes are now imported as the same format as WPA hashes, as Hashcat treats them similarly in output formats.

closes #603 