### PR TITLE
add gitignore for working directories

### DIFF
--- a/src/files/.gitignore
+++ b/src/files/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.htaccess

--- a/src/import/.gitignore
+++ b/src/import/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.htaccess

--- a/src/log/.gitignore
+++ b/src/log/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.htaccess

--- a/src/tmp/.gitignore
+++ b/src/tmp/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.htaccess


### PR DESCRIPTION
Running `git status` or `git ls-files` on a deployed instance of
hashtopolis is noisy, because working files show up as untracked.

This commit gitignores everything but .htaccess and .gitignore in

src/files/
src/import/
src/log/
src/tmp/