### PR TITLE
Allow monitoring of agent cpu utilisation data

### DIFF
--- a/src/agentStatus.php
+++ b/src/agentStatus.php
@@ -55,7 +55,7 @@ foreach ($stats as $stat) {
     $agentStats->addValue($stat->getAgentId(), $stat);
   }
 }
-UI::add('stats', $agentStats);
+UI::add('gpuStats', $agentStats);
 
 $oF1 = new OrderFilter(AgentStat::AGENT_ID, "ASC");
 $oF2 = new OrderFilter(AgentStat::TIME, "DESC");
@@ -69,7 +69,21 @@ foreach ($stats as $stat) {
     $agentStats->addValue($stat->getAgentId(), $stat);
   }
 }
-UI::add('temps', $agentStats);
+UI::add('gpuTemps', $agentStats);
+
+$oF1 = new OrderFilter(AgentStat::AGENT_ID, "ASC");
+$oF2 = new OrderFilter(AgentStat::TIME, "DESC");
+$qF1 = new ContainFilter(AgentStat::AGENT_ID, $agentIds);
+$qF2 = new QueryFilter(AgentStat::STAT_TYPE, DAgentStatsType::CPU_UTIL, "=");
+$qF3 = new QueryFilter(AgentStat::TIME, time() - SConfig::getInstance()->getVal(DConfig::AGENT_TIMEOUT), ">");
+$stats = Factory::getAgentStatFactory()->filter([Factory::FILTER => [$qF1, $qF2, $qF3], Factory::ORDER => [$oF1, $oF2]]);
+$agentStats = new DataSet();
+foreach ($stats as $stat) {
+    if ($agentStats->getVal($stat->getAgentId()) === false) {
+        $agentStats->addValue($stat->getAgentId(), $stat);
+    }
+}
+UI::add('cpuStats', $agentStats);
 
 echo Template::getInstance()->render(UI::getObjects());
 

--- a/src/agents.php
+++ b/src/agents.php
@@ -77,17 +77,23 @@ if (isset($_GET['id'])) {
     
     // load agent detail data
     $data = AgentUtils::getGraphData($agent, [DAgentStatsType::GPU_TEMP]);
-    UI::add('deviceTemp', json_encode($data['sets']));
-    UI::add('deviceTempAvailable', (sizeof($data['sets']) > 0) ? true : false);
-    UI::add('deviceTempXLabels', json_encode($data['xlabels']));
-    UI::add('deviceTempAxes', json_encode($data['axes']));
+    UI::add('deviceGpuTemp', json_encode($data['sets']));
+    UI::add('deviceGpuTempAvailable', (sizeof($data['sets']) > 0) ? true : false);
+    UI::add('deviceGpuTempXLabels', json_encode($data['xlabels']));
+    UI::add('deviceGpuTempAxes', json_encode($data['axes']));
     
     $data = AgentUtils::getGraphData($agent, [DAgentStatsType::GPU_UTIL]);
-    UI::add('deviceUtil', json_encode($data['sets']));
-    UI::add('deviceUtilAvailable', (sizeof($data['sets']) > 0) ? true : false);
-    UI::add('deviceUtilXLabels', json_encode($data['xlabels']));
-    UI::add('deviceUtilAxes', json_encode($data['axes']));
-    
+    UI::add('deviceGpuUtil', json_encode($data['sets']));
+    UI::add('deviceGpuUtilAvailable', (sizeof($data['sets']) > 0) ? true : false);
+    UI::add('deviceGpuUtilXLabels', json_encode($data['xlabels']));
+    UI::add('deviceGpuUtilAxes', json_encode($data['axes']));
+
+    $data = AgentUtils::getGraphData($agent, [DAgentStatsType::CPU_UTIL]);
+    UI::add('deviceCpuUtil', json_encode($data['sets']));
+    UI::add('deviceCpuUtilAvailable', (sizeof($data['sets']) > 0) ? true : false);
+    UI::add('deviceCpuUtilXLabels', json_encode($data['xlabels']));
+    UI::add('deviceCpuUtilAxes', json_encode($data['axes']));
+
     $qF = new QueryFilter(Assignment::AGENT_ID, $agent->getId(), "=");
     $assignment = Factory::getAssignmentFactory()->filter([Factory::FILTER => $qF], true);
     $currentTask = 0;

--- a/src/inc/api/APISendProgress.class.php
+++ b/src/inc/api/APISendProgress.class.php
@@ -106,7 +106,17 @@ class APISendProgress extends APIBasic {
       $agentStat = new AgentStat(null, $this->agent->getId(), DAgentStatsType::GPU_UTIL, $dataTime, $data);
       Factory::getAgentStatFactory()->save($agentStat);
     }
-    
+    if (isset($QUERY[PQuerySendProgress::CPU_UTIL])) {
+      for ($i = 0; $i < sizeof($QUERY[PQuerySendProgress::CPU_UTIL]); $i++) {
+        if (!is_numeric($QUERY[PQuerySendProgress::CPU_UTIL][$i]) || $QUERY[PQuerySendProgress::CPU_UTIL][$i] < 0) {
+          unset($QUERY[PQuerySendProgress::CPU_UTIL][$i]);
+        }
+      }
+      $data = implode(",", $QUERY[PQuerySendProgress::CPU_UTIL]);
+      $agentStat = new AgentStat(null, $this->agent->getId(), DAgentStatsType::CPU_UTIL, $dataTime, $data);
+      Factory::getAgentStatFactory()->save($agentStat);
+    }
+
     // agent is assigned to this chunk (not necessarily task!)
     // it can be already assigned to other task, but is still computing this chunk until it realizes it
     $skip = $chunk->getSkip();

--- a/src/inc/defines/agents.php
+++ b/src/inc/defines/agents.php
@@ -28,6 +28,7 @@ class DAgentIgnoreErrors {
 class DAgentStatsType {
   const GPU_TEMP = 1;
   const GPU_UTIL = 2;
+  const CPU_UTIL = 3;
 }
 
 class DAgentAction {

--- a/src/inc/defines/config.php
+++ b/src/inc/defines/config.php
@@ -355,7 +355,7 @@ class DConfig {
       case DConfig::AGENT_STAT_LIMIT:
         return "Maximal number of data points showing of agent gpu data.";
       case DConfig::AGENT_DATA_LIFETIME:
-        return "Minimum time in seconds how long agent data about gpu temperature and utility is kept on the server.";
+        return "Minimum time in seconds how long agent gpu/cpu utilisation and gpu temperature data is kept on the server.";
       case DConfig::AGENT_STAT_TENSION:
         return "Draw straigth lines in agent data graph  instead of bezier curves.";
       case DConfig::MULTICAST_ENABLE:

--- a/src/inc/protocol.php
+++ b/src/inc/protocol.php
@@ -59,6 +59,7 @@ class PQuerySendProgress extends PQuery {
   const DEBUG_OUTPUT = "debugOutput";
   const GPU_TEMP     = "gpuTemp";
   const GPU_UTIL     = "gpuUtil";
+  const CPU_UTIL     = "cpuUtil";
 }
 
 class PQuerySendBenchmark extends PQuery {

--- a/src/templates/agents/detail.temperature.template.html
+++ b/src/templates/agents/detail.temperature.template.html
@@ -1,16 +1,17 @@
-{{IF [[deviceTempAvailable]] > 0}}
-    <h3>Device(s) Temperature</h3>
+{{IF [[deviceGpuTempAvailable]] > 0}}
+    <hr>
+    <h3>Device(s) GPU Temperature</h3>
     <div class="row">
         <div class="col col-12">
-            <canvas id="deviceTemp"></canvas>
+            <canvas id="deviceGpuTemp"></canvas>
         </div>
     </div>
     <script type="text/javascript">
         var configTemp = {
             type: 'line',
             data: {
-                labels: [[deviceTempXLabels]],
-                datasets: [[deviceTemp]]
+                labels: [[deviceGpuTempXLabels]],
+                datasets: [[deviceGpuTemp]]
             },
             options: {
                 responsive: true,
@@ -31,29 +32,33 @@
                             labelString: 'Time'
                         }
                     }],
-                    yAxes: [[deviceTempAxes]]
+                    yAxes: [[deviceGpuTempAxes]]
                 }
             }
         };
         $( document ).ready(function() {
-            new Chart(document.getElementById('deviceTemp').getContext('2d'), configTemp);
+            new Chart(document.getElementById('deviceGpuTemp').getContext('2d'), configTemp);
         });
     </script>
+{{ELSE}}
+    <hr>
+    <i>GPU temperature data unavailable</i>
 {{ENDIF}}
 
-{{IF [[deviceUtilAvailable]] > 0}}
-    <h3>Device(s) Util</h3>
+{{IF [[deviceGpuUtilAvailable]] > 0}}
+    <hr>
+    <h3>Device(s) GPU utilisation</h3>
     <div class="row">
         <div class="col col-12">
-            <canvas id="deviceUtil"></canvas>
+            <canvas id="deviceGpuUtil"></canvas>
         </div>
     </div>
     <script type="text/javascript">
         var configUtil = {
             type: 'line',
             data: {
-                labels: [[deviceUtilXLabels]],
-                datasets: [[deviceUtil]]
+                labels: [[deviceGpuUtilXLabels]],
+                datasets: [[deviceGpuUtil]]
             },
             options: {
                 responsive: true,
@@ -74,12 +79,62 @@
                             labelString: 'Time'
                         }
                     }],
-                    yAxes: [[deviceUtilAxes]]
+                    yAxes: [[deviceGpuUtilAxes]]
                 }
             }
         };
         $( document ).ready(function() {
-            new Chart(document.getElementById('deviceUtil').getContext('2d'), configUtil);
+            new Chart(document.getElementById('deviceGpuUtil').getContext('2d'), configUtil);
         });
     </script>
+{{ELSE}}
+    <hr>
+    <i>GPU utilisation data unavailable</i>
+{{ENDIF}}
+
+{{IF [[deviceCpuUtilAvailable]] > 0}}
+    <hr>
+    <h3>Agent average CPU utilisation</h3>
+    <div class="row">
+        <div class="col col-12">
+            <canvas id="deviceCpuUtil"></canvas>
+        </div>
+    </div>
+    <script type="text/javascript">
+        var configCpuUtil = {
+            type: 'line',
+            data: {
+                labels: [[deviceCpuUtilXLabels]],
+                datasets: [[deviceCpuUtil]]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                tooltips: {
+                    mode: 'index',
+                    intersect: false
+                },
+                hover: {
+                    mode: 'nearest',
+                    intersect: true
+                },
+                scales: {
+                    xAxes: [{
+                        display: true,
+                        scaleLabel: {
+                            display: true,
+                            labelString: 'Time'
+                        }
+                    }],
+                    yAxes: [[deviceCpuUtilAxes]]
+                }
+            }
+        };
+        $( document ).ready(function() {
+            new Chart(document.getElementById('deviceCpuUtil').getContext('2d'), configCpuUtil);
+        });
+    </script>
+{{ELSE}}
+    <hr>
+    <i>CPU utilisation data unavailable</i>
 {{ENDIF}}

--- a/src/templates/agents/status.template.html
+++ b/src/templates/agents/status.template.html
@@ -1,66 +1,97 @@
 {%TEMPLATE->struct/head%}
 {%TEMPLATE->struct/menu%}
-<h2>Agents Status ([[sizeof([[agents]])]])</h2>
+<h2>Agents status ([[sizeof([[agents]])]])</h2>
 {%TEMPLATE->struct/messages%}
 <hr>
-<h3>Devices Util</h3>
+<h3>Average GPU utilisation</h3>
 <div class="container-fluid">
   <div class="row">
     {{FOREACH agent;[[agents]]}}
-      <div class="col-lg-1 col-md-2 col-sm-3 col-4 text-center" style="background-color: [[AgentUtils::getUtilStatusColor([[stats.getVal([[agent.getId()]])]], [[agent]])]]; border: 1px solid #808080;">
+      <div class="col-lg-1 col-md-2 col-sm-3 col-4 text-center" style="background-color: [[AgentUtils::getGpuUtilStatusColor([[gpuStats.getVal([[agent.getId()]])]], [[agent]])]]; border: 1px solid #808080;">
         <a href="agents.php?id=[[agent.getId()]]" class="btn btn-light my-1" data-toggle="tooltip" data-placement="top" title="View Agent ([[agent.getAgentName()]])"><i class="fas fa-eye" aria-hidden="true"></i></a>
       </div>
     {{ENDFOREACH}}
   </div>
   <div class="row">
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #009933;">■</span> Utility is good (> [[config.getVal([[$DConfig::AGENT_UTIL_THRESHOLD_1]])]]%)
+      <span style="color: #009933;">■</span> GPU utilisation is good (> [[config.getVal([[$DConfig::AGENT_UTIL_THRESHOLD_1]])]]%)
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #ff9900;">■</span> Utility not ideal (<= [[config.getVal([[$DConfig::AGENT_UTIL_THRESHOLD_1]])]]%)
+      <span style="color: #ff9900;">■</span> GPU utilisation not ideal (<= [[config.getVal([[$DConfig::AGENT_UTIL_THRESHOLD_1]])]]%)
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #800000;">■</span> Utility low (<= [[config.getVal([[$DConfig::AGENT_UTIL_THRESHOLD_2]])]]%)
+      <span style="color: #800000;">■</span> GPU utilisation low (<= [[config.getVal([[$DConfig::AGENT_UTIL_THRESHOLD_2]])]]%)
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
       <span style="color: #CCCCCC;">■</span> Agent is not active
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #42d4f4;">■</span> Agent is active but not working or not providing data
+      <span style="color: #42d4f4;">■</span> Agent is active but not working or not providing GPU data
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #FF0000;">■</span> Invalid data from agent or values being 0
+      <span style="color: #FF0000;">■</span> Invalid GPU data from agent or values being 0
     </div>
   </div>
 </div>
 <hr>
-<h3>Devices Temperatures</h3>
+<h3>Highest GPU Temperature</h3>
 <div class="container-fluid">
   <div class="row">
     {{FOREACH agent;[[agents]]}}
-    <div class="col-lg-1 col-md-2 col-sm-3 col-4 text-center" style="background-color: [[AgentUtils::getTempStatusColor([[temps.getVal([[agent.getId()]])]], [[agent]])]]; border: 1px solid #808080;">
+    <div class="col-lg-1 col-md-2 col-sm-3 col-4 text-center" style="background-color: [[AgentUtils::getGpuTempStatusColor([[gpuTemps.getVal([[agent.getId()]])]], [[agent]])]]; border: 1px solid #808080;">
       <a href="agents.php?id=[[agent.getId()]]" class="btn btn-light my-1" data-toggle="tooltip" data-placement="top" title="View Agent ([[agent.getAgentName()]])"><i class="fas fa-eye" aria-hidden="true"></i></a>
     </div>
     {{ENDFOREACH}}
   </div>
   <div class="row">
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #009933;">■</span> Temperature good (<= [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_1]])]]°C)
+      <span style="color: #009933;">■</span> GPU Temperatures good (<= [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_1]])]]°C)
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #ff9900;">■</span> Temperature acceptable (<= [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_2]])]]°C)
+      <span style="color: #ff9900;">■</span> GPU Temperatures acceptable (<= [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_2]])]]°C)
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #800000;">■</span> Temperature too high (> [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_2]])]]°C)
+      <span style="color: #800000;">■</span> GPU Temperatures too high (> [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_2]])]]°C)
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
       <span style="color: #CCCCCC;">■</span> Agent is not active
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #42d4f4;">■</span> Agent is active but not working or not providing data
+      <span style="color: #42d4f4;">■</span> Agent is active but not working or not providing GPU data
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #FF0000;">■</span> Invalid data from agent or values being 0
+      <span style="color: #FF0000;">■</span> Invalid GPU data from agent or values being 0
+    </div>
+  </div>
+</div>
+<hr>
+<h3>Average CPU utilisation</h3>
+<div class="container-fluid">
+  <div class="row">
+    {{FOREACH agent;[[agents]]}}
+    <div class="col-lg-1 col-md-2 col-sm-3 col-4 text-center" style="background-color: [[AgentUtils::getCpuUtilStatusColor([[cpuStats.getVal([[agent.getId()]])]], [[agent]])]]; border: 1px solid #808080;">
+      <a href="agents.php?id=[[agent.getId()]]" class="btn btn-light my-1" data-toggle="tooltip" data-placement="top" title="View Agent ([[agent.getAgentName()]])"><i class="fas fa-eye" aria-hidden="true"></i></a>
+    </div>
+    {{ENDFOREACH}}
+  </div>
+  <div class="row">
+    <div class="col-lg-2 col-md-4 col-sm-12">
+      <span style="color: #009933;">■</span> CPU utilisation is good (> [[config.getVal([[$DConfig::AGENT_UTIL_THRESHOLD_1]])]]%)
+    </div>
+    <div class="col-lg-2 col-md-4 col-sm-12">
+      <span style="color: #ff9900;">■</span> CPU utilisation not ideal (<= [[config.getVal([[$DConfig::AGENT_UTIL_THRESHOLD_1]])]]%)
+    </div>
+    <div class="col-lg-2 col-md-4 col-sm-12">
+      <span style="color: #800000;">■</span> CPU utilisation low (<= [[config.getVal([[$DConfig::AGENT_UTIL_THRESHOLD_2]])]]%)
+    </div>
+    <div class="col-lg-2 col-md-4 col-sm-12">
+      <span style="color: #CCCCCC;">■</span> Agent is not active
+    </div>
+    <div class="col-lg-2 col-md-4 col-sm-12">
+      <span style="color: #42d4f4;">■</span> Agent is active but not working or not providing CPU data
+    </div>
+    <div class="col-lg-2 col-md-4 col-sm-12">
+      <span style="color: #FF0000;">■</span> Invalid CPU data from agent or values being 0
     </div>
   </div>
 </div>


### PR DESCRIPTION
Show average CPU utilisation data per agent on agent status page.
Display a graph of average CPU utilisation on the agent detail page.

Note that this requires an update of the hashtopolis-agent-python code in order for the agent to send the CPU utilisation data to hashtopolis. Import available psutil package in hashcat_cracker.py and add after line 315: 
`query['cpuUtil'] = psutil.cpu_percent()`
This change is proposed in a pull request: https://github.com/s3inlc/hashtopolis-agent-python/pull/10