### PR TITLE
fix improper decrement calls in HashlistUtils::delete()

### DIFF
--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -496,9 +496,9 @@ class HashlistUtils {
     $superHashlists = $joined[Factory::getHashlistFactory()->getModelName()];
     $toDelete = [];
     foreach ($superHashlists as $superHashlist) {
-      Factory::getHashlistFactory()->dec($superHashlist, $hashlist->getHashCount());
-      Factory::getHashlistFactory()->dec($superHashlist, $hashlist->getCracked());
-      
+      Factory::getHashlistFactory()->dec($superHashlist, Hashlist::HASH_COUNT, $hashlist->getHashCount());
+      Factory::getHashlistFactory()->dec($superHashlist, Hashlist::CRACKED, $hashlist->getCracked());
+  
       if ($superHashlist->getHashCount() <= 0) {
         // this superhashlist has no hashlist which belongs to it anymore -> delete it
         $toDelete[] = $superHashlist;


### PR DESCRIPTION
Currently, attempting to delete a hashlist which is part of a superhashlist does not complete properly and results in a blank page.

This fixes the error which was due to not providing a column key to Factory::getHashlistFactory->dec().