### PR TITLE
Show agent activity overview on agentstatus page

### DIFF
--- a/src/agentStatus.php
+++ b/src/agentStatus.php
@@ -85,6 +85,31 @@ foreach ($stats as $stat) {
 }
 UI::add('cpuStats', $agentStats);
 
+$agentTasks = new DataSet();
+$agentSpeeds = new DataSet();
+$agentChunks = new DataSet();
+$agentAssignments = new DataSet();
+$agents = Factory::getAgentFactory()->filter([Factory::FILTER => $qF, Factory::ORDER => $oF]);
+foreach ($agents as $agent) {
+  $qF1 = new QueryFilter(\DBA\Chunk::AGENT_ID, $agent->getId(), "=");
+  $qF2 = new QueryFilter(\DBA\Chunk::SPEED, 0, ">");
+  $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
+  foreach ($chunks as $chunk) {
+    $agentTasks->addValue($agent->getId(), $chunk->getTaskId());
+    $agentSpeeds->addValue($agent->getId(), $chunk->getSpeed());
+    $agentChunks->addValue($agent->getId(), $chunk->getId());
+  }
+  $qF = new QueryFilter(\DBA\Assignment::AGENT_ID, $agent->getId(), "=");
+  $assignment = Factory::getAssignmentFactory()->filter([Factory::FILTER => $qF], true);
+  if ($assignment != null) {
+    $agentAssignments->addValue($agent->getId(), $assignment->getTaskId());
+  }
+}
+UI::add('agentAssignments', $agentAssignments);
+UI::add('agentSpeeds', $agentSpeeds);
+UI::add('agentTasks', $agentTasks);
+UI::add('agentChunks', $agentChunks);
+
 echo Template::getInstance()->render(UI::getObjects());
 
 

--- a/src/templates/agents/status.template.html
+++ b/src/templates/agents/status.template.html
@@ -95,4 +95,79 @@
     </div>
   </div>
 </div>
+<h3>Agents activity ([[sizeof([[agents]])]])</h3>
+<div class="card">
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <tr>
+        <th>Agent ID</th>
+        <th>Name</th>
+        <th>Currently working on</th>
+        <th>Assigned to</th>
+        <th>Last activity</th>
+      </tr>
+      {{FOREACH agent;[[agents]]}}
+      <tr>
+        <td>
+          {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_AGENT_ACCESS]])]]}}
+          <a href="agents.php?id=[[agent.getId()]]">[[agent.getId()]]</a>
+          {{ELSE}}
+          [[agent.getId()]]
+          {{ENDIF}}
+          {{IF [[activeAgents.getVal([[agent.getId()]])]] == 1}}
+          <i class="fas fa-spinner fa-spin"></i>
+          {{ENDIF}}
+        </td>
+        <td>
+          {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_AGENT_ACCESS]])]]}}
+          <a href="agents.php?id=[[agent.getId()]]">[[agent.getAgentName()]]</a>
+          {{ELSE}}
+          [[agent.getAgentName()]]
+          {{ENDIF}}
+          {{IF [[agent.getIsTrusted()]] == 1}}
+          <span class="fas fa-lock" aria-hidden="true"></span>
+          {{ENDIF}}
+          {{IF [[agent.getIsActive()]] == 0}}
+          <span class="fas fa-pause" aria-hidden="true"></span>
+          {{ENDIF}}
+        </td>
+        <td>
+          {{IF [[agentTasks.getVal([[agent.getId()]])]]}}
+          {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_TASK_ACCESS]])]]}}
+          <a href="tasks.php?id=[[agentTasks.getVal([[agent.getId()]])]]">Task [[agentTasks.getVal([[agent.getId()]])]]</a>,
+          at [[Util::nicenum([[agentSpeeds.getVal([[agent.getId()]])]], 10000, 1000)]]H/s,
+          working on chunk [[agentChunks.getVal([[agent.getId()]])]] <i class="fas fa-spinner fa-spin"></i>
+          {{ELSE}}
+          Task Id [[agentTasks.getVal([[agent.getId()]])]] <i class="fas fa-spinner fa-spin"></i>
+          {{ENDIF}}
+          {{ELSE}}
+          ---
+          {{ENDIF}}
+        </td>
+        <td>
+          {{IF [[agentAssignments.getVal([[agent.getId()]])]]}}
+          {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_TASK_ACCESS]])]]}}
+          <a href="tasks.php?id=[[agentAssignments.getVal([[agent.getId()]])]]">Task [[agentAssignments.getVal([[agent.getId()]])]]</a><br>
+          {{ELSE}}
+          Task [[agentAssignments.getVal([[agent.getId()]])]]<br>
+          {{ENDIF}}
+          {{ELSE}}
+          ---
+          {{ENDIF}}
+        </td>
+        <td>
+          Action: [[agent.getLastAct()]]<br>
+          Time: [[date([[config.getVal(DConfig::TIME_FORMAT)]], [[agent.getLastTime()]])]]<br>
+          IP:
+          {{IF [[config.getVal([[$DConfig::HIDE_IP_INFO]])]] == 0}}
+          <code>[[agent.getLastIp()]]</code>
+          {{ELSE}}
+          <code>Hidden</code>
+          {{ENDIF}}
+        </td>
+      </tr>
+      {{ENDFOREACH}}
+    </table>
+  </div>
+</div>
 {%TEMPLATE->struct/foot%}


### PR DESCRIPTION
Includes per agent: current hashing speed, chunk id, task, assignment and last activity.