### PR TITLE
Allow changing status interval per task

### DIFF
--- a/src/inc/defines/config.php
+++ b/src/inc/defines/config.php
@@ -297,7 +297,7 @@ class DConfig {
       case DConfig::HASHLIST_ALIAS:
         return "The string used as hashlist alias when creating a task.";
       case DConfig::STATUS_TIMER:
-        return "Interval in seconds clients should report back to the server. (cracks, status, and progress).";
+        return "Default interval in seconds clients should report back to the server for a task. (cracks, status, and progress).";
       case DConfig::BLACKLIST_CHARS:
         return "Characters that are not allowed to be used in attack command inputs.";
       case DConfig::NUMBER_LOGENTRIES:

--- a/src/inc/defines/tasks.php
+++ b/src/inc/defines/tasks.php
@@ -117,4 +117,7 @@ class DTaskAction {
   
   const EDIT_NOTES      = "editNotes";
   const EDIT_NOTES_PERM = DAccessControl::MANAGE_TASK_ACCESS;
+  
+  const SET_STATUS_TIMER = "setStatusTimer";
+  const SET_STATUS_TIMER_PERM = DAccessControl::MANAGE_TASK_ACCESS;
 }

--- a/src/inc/handlers/TaskHandler.class.php
+++ b/src/inc/handlers/TaskHandler.class.php
@@ -69,6 +69,10 @@ class TaskHandler implements Handler {
           AccessControl::getInstance()->checkPermission(DTaskAction::DELETE_TASK_PERM);
           TaskUtils::delete($_POST['task'], Login::getInstance()->getUser());
           break;
+        case DTaskAction::SET_STATUS_TIMER:
+          AccessControl::getInstance()->checkPermission(DTaskAction::SET_STATUS_TIMER_PERM);
+          TaskUtils::updateStatusTimer($_POST['task'], $_POST['statusTimer'], Login::getInstance()->getUser());
+          break;
         case DTaskAction::SET_PRIORITY:
           AccessControl::getInstance()->checkPermission(DTaskAction::SET_PRIORITY_PERM);
           TaskUtils::updatePriority($_POST["task"], $_POST['priority'], Login::getInstance()->getUser());

--- a/src/templates/tasks/detail.template.html
+++ b/src/templates/tasks/detail.template.html
@@ -132,7 +132,19 @@
       </tr>
       <tr>
         <td>Status timer:</td>
-        <td>[[task.getStatusTimer()]] seconds</td>
+        <td>
+          {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_TASK_ACCESS]])]]}}
+          <form class='form-inline' action="tasks.php?id=[[task.getId()]]" method="POST" onSubmit="if (!confirm('This change only takes effect on an agent running this task when either a chunk is aborted or the agent is reactivated/restarted.')) return false;">
+            <input type="hidden" name="action" value="[[$DTaskAction::SET_STATUS_TIMER]]">
+            <input type="hidden" name="task" value="[[task.getId()]]">
+            <input type="hidden" name="csrf" value="[[csrf]]">
+            <input type="text" class='form-control' name="statusTimer" size="4" value="[[task.getStatusTimer()]]" title="Status timer">&nbsp;&nbsp;
+            <button type="submit" class='btn {{IF [[toggledarkmode]] > 0}}btn-primary{{ELSE}}btn-light{{ENDIF}}' data-toggle="tooltip" data-placement="top" title="Set"><i class="fas fa-save" aria-hidden="true"></i></button>
+          </form>
+          {{ELSE}}
+            [[task.getStatusTimer()]] seconds
+          {{ENDIF}}
+        </td>
       </tr>
       <tr>
         <td>Priority:</td>


### PR DESCRIPTION
  Allow to change the status interval on the task detail page, i.e. after a task is already created. Previously one could only change this default value upon task creation.
  Note that once a client is running a task, it does not yet automatically adapt the new status timer value. A pop-up message reminding the user of this property is shown when the status interval is changed.