### PR TITLE
User-api / abort chunks group

### DIFF
--- a/src/inc/defines/userApi.php
+++ b/src/inc/defines/userApi.php
@@ -926,10 +926,11 @@ class USectionUser extends UApi {
 }
 
 class USectionGroup extends UApi {
-  const LIST_GROUPS  = "listGroups";
-  const GET_GROUP    = "getGroup";
-  const CREATE_GROUP = "createGroup";
-  const DELETE_GROUP = "deleteGroup";
+  const LIST_GROUPS        = "listGroups";
+  const GET_GROUP          = "getGroup";
+  const CREATE_GROUP       = "createGroup";
+  const ABORT_CHUNKS_GROUP = "abortChunksGroup";
+  const DELETE_GROUP       = "deleteGroup";
   
   const ADD_AGENT    = "addAgent";
   const ADD_USER     = "addUser";
@@ -944,6 +945,8 @@ class USectionGroup extends UApi {
         return "Get details of a group";
       case USectionGroup::CREATE_GROUP:
         return "Create new groups";
+      case USectionGroup::ABORT_CHUNKS_GROUP:
+        return "Abort all chunks dispatched to agents of this group";
       case USectionGroup::DELETE_GROUP:
         return "Delete groups";
       case USectionGroup::ADD_AGENT:

--- a/src/inc/user-api/UserAPIGroup.class.php
+++ b/src/inc/user-api/UserAPIGroup.class.php
@@ -13,6 +13,9 @@ class UserAPIGroup extends UserAPIBasic {
         case USectionGroup::CREATE_GROUP:
           $this->createGroup($QUERY);
           break;
+        case USectionGroup::ABORT_CHUNKS_GROUP:
+          $this->abortChunksGroup($QUERY);
+          break;
         case USectionGroup::DELETE_GROUP:
           $this->deleteGroup($QUERY);
           break;
@@ -106,6 +109,18 @@ class UserAPIGroup extends UserAPIBasic {
       throw new HTException("Invalid query!");
     }
     AccessGroupUtils::createGroup($QUERY[UQueryGroup::GROUP_NAME]);
+    $this->sendSuccessResponse($QUERY);
+  }
+  
+  /**
+   * @param array $QUERY
+   * @throws HTException
+   */
+  private function abortChunksGroup($QUERY) {
+    if (!isset($QUERY[UQueryGroup::GROUP_ID])) {
+      throw new HTException("Invalid query!");
+    }
+    AccessGroupUtils::abortChunksGroup($QUERY[UQueryGroup::GROUP_ID], $this->user);
     $this->sendSuccessResponse($QUERY);
   }
   


### PR DESCRIPTION
Allow to abort all chunks with hashcat status 'running' or 'init' belonging to all agents in a specified access group. This forces every agent in the group to drop his current chunk and request a new one, which in turn causes the server to automatically check whether there exists a task with a higher priority.

```
    The client requests chunks to be aborted for agents belonging to a specific access group.

    {
    "section": "group",
    "request": "abortChunksGroup",
    "groupId": "1",
    "accessKey": "<myKey>"
    }

    The server should reply following on success:

    {
        "section": "group",
        "request": "abortChunksGroup",
        "response": "OK"
    }
```