### PR TITLE
User-api / set task to top priority

### DIFF
--- a/src/inc/defines/tasks.php
+++ b/src/inc/defines/tasks.php
@@ -94,6 +94,9 @@ class DTaskAction {
   const SET_PRIORITY      = "setPriority";
   const SET_PRIORITY_PERM = DAccessControl::MANAGE_TASK_ACCESS;
   
+  const SET_TOP_PRIORITY = "setTopPriority";
+  const SET_TOP_PRIORITY_PERM = DAccessControl::MANAGE_TASK_ACCESS;
+  
   const CREATE_TASK      = "createTask";
   const CREATE_TASK_PERM = DAccessControl::CREATE_TASK_ACCESS;
   
@@ -102,6 +105,9 @@ class DTaskAction {
   
   const SET_SUPERTASK_PRIORITY      = "setSupertaskPriority";
   const SET_SUPERTASK_PRIORITY_PERM = DAccessControl::MANAGE_TASK_ACCESS;
+  
+  const SET_SUPERTASK_TOP_PRIORITY      = "setSupertaskTopPriority";
+  const SET_SUPERTASK_TOP_PRIORITY_PERM = DAccessControl::MANAGE_TASK_ACCESS;
   
   const ARCHIVE_TASK      = "archiveTask";
   const ARCHIVE_TASK_PERM = DAccessControl::CREATE_TASK_ACCESS;

--- a/src/inc/defines/userApi.php
+++ b/src/inc/defines/userApi.php
@@ -599,16 +599,18 @@ class USectionTask extends UApi {
   const RUN_PRETASK   = "runPretask";
   const RUN_SUPERTASK = "runSupertask";
   
-  const SET_TASK_PRIORITY      = "setTaskPriority";
-  const SET_SUPERTASK_PRIORITY = "setSupertaskPriority";
-  const SET_TASK_NAME          = "setTaskName";
-  const SET_TASK_COLOR         = "setTaskColor";
-  const SET_TASK_CPU_ONLY      = "setTaskCpuOnly";
-  const SET_TASK_SMALL         = "setTaskSmall";
-  const TASK_UNASSIGN_AGENT    = "taskUnassignAgent";
-  const TASK_ASSIGN_AGENT      = "taskAssignAgent";
-  const DELETE_TASK            = "deleteTask";
-  const PURGE_TASK             = "purgeTask";
+  const SET_TASK_PRIORITY          = "setTaskPriority";
+  const SET_TASK_TOP_PRIORITY      = "setTaskTopPriority";
+  const SET_SUPERTASK_PRIORITY     = "setSupertaskPriority";
+  const SET_SUPERTASK_TOP_PRIORITY = "setSupertaskTopPriority";
+  const SET_TASK_NAME              = "setTaskName";
+  const SET_TASK_COLOR             = "setTaskColor";
+  const SET_TASK_CPU_ONLY          = "setTaskCpuOnly";
+  const SET_TASK_SMALL             = "setTaskSmall";
+  const TASK_UNASSIGN_AGENT        = "taskUnassignAgent";
+  const TASK_ASSIGN_AGENT          = "taskAssignAgent";
+  const DELETE_TASK                = "deleteTask";
+  const PURGE_TASK                 = "purgeTask";
   
   const SET_SUPERTASK_NAME = "setSupertaskName";
   const DELETE_SUPERTASK   = "deleteSupertask";
@@ -634,8 +636,12 @@ class USectionTask extends UApi {
         return "Run a configured supertask with a hashlist";
       case USectionTask::SET_TASK_PRIORITY:
         return "Set the priority of a task";
+      case USectionTask::SET_TASK_TOP_PRIORITY:
+        return "Set task priority to the previous highest plus one hundred";
       case USectionTask::SET_SUPERTASK_PRIORITY:
         return "Set the priority of a supertask";
+      case USectionTask::SET_SUPERTASK_TOP_PRIORITY:
+        return "Set supertask priority to the previous highest plus one hundred";
       case USectionTask::SET_TASK_NAME:
         return "Rename a task";
       case USectionTask::SET_TASK_COLOR:

--- a/src/inc/handlers/TaskHandler.class.php
+++ b/src/inc/handlers/TaskHandler.class.php
@@ -73,6 +73,10 @@ class TaskHandler implements Handler {
           AccessControl::getInstance()->checkPermission(DTaskAction::SET_PRIORITY_PERM);
           TaskUtils::updatePriority($_POST["task"], $_POST['priority'], Login::getInstance()->getUser());
           break;
+        case DTaskAction::SET_TOP_PRIORITY:
+          AccessControl::getInstance()->checkPermission(DTaskAction::SET_PRIORITY_PERM);
+          TaskUtils::updatePriority($_POST["task"], -1, Login::getInstance()->getUser(), true);
+          break;
         case DTaskAction::CREATE_TASK:
           AccessControl::getInstance()->checkPermission(array_merge(DTaskAction::CREATE_TASK_PERM, DAccessControl::RUN_TASK_ACCESS));
           $this->create();
@@ -84,6 +88,10 @@ class TaskHandler implements Handler {
         case DTaskAction::SET_SUPERTASK_PRIORITY:
           AccessControl::getInstance()->checkPermission(DTaskAction::SET_SUPERTASK_PRIORITY_PERM);
           TaskUtils::setSupertaskPriority($_POST['supertaskId'], $_POST['priority'], Login::getInstance()->getUser());
+          break;
+        case DTaskAction::SET_SUPERTASK_TOP_PRIORITY:
+          AccessControl::getInstance()->checkPermission(DTaskAction::SET_SUPERTASK_PRIORITY_PERM);
+          TaskUtils::setSupertaskPriority($_POST['supertaskId'], -1, Login::getInstance()->getUser(), true);
           break;
         case DTaskAction::ARCHIVE_TASK:
           AccessControl::getInstance()->checkPermission(DTaskAction::ARCHIVE_TASK_PERM);

--- a/src/inc/user-api/UserAPITask.class.php
+++ b/src/inc/user-api/UserAPITask.class.php
@@ -28,8 +28,14 @@ class UserAPITask extends UserAPIBasic {
         case USectionTask::SET_TASK_PRIORITY:
           $this->setTaskPriority($QUERY);
           break;
+        case USectionTask::SET_TASK_TOP_PRIORITY:
+          $this->setTaskPriority($QUERY, true);
+          break;
         case USectionTask::SET_SUPERTASK_PRIORITY:
           $this->setSuperTaskPriority($QUERY);
+          break;
+        case USectionTask::SET_SUPERTASK_TOP_PRIORITY:
+          $this->setSuperTaskPriority($QUERY, true);
           break;
         case USectionTask::SET_TASK_NAME:
           $this->setTaskName($QUERY);
@@ -243,25 +249,43 @@ class UserAPITask extends UserAPIBasic {
   
   /**
    * @param array $QUERY
+   * @param bool $topPriority
    * @throws HTException
    */
-  private function setTaskPriority($QUERY) {
+  private function setTaskPriority($QUERY, $topPriority = false) {
     if (!isset($QUERY[UQueryTask::TASK_ID]) || !isset($QUERY[UQueryTask::TASK_PRIORITY])) {
       throw new HTException("Invalid query!");
     }
-    TaskUtils::updatePriority($QUERY[UQueryTask::TASK_ID], $QUERY[UQueryTask::TASK_PRIORITY], $this->user);
+    if ($topPriority) {
+      TaskUtils::updatePriority($QUERY[UQueryTask::TASK_ID], -1, $this->user, true);
+    }
+    else {
+      if (!isset($QUERY[UQueryTask::TASK_PRIORITY])) {
+        throw new HTException("Invalid query!");
+      }
+      TaskUtils::updatePriority($QUERY[UQueryTask::TASK_ID], $QUERY[UQueryTask::TASK_PRIORITY], $this->user);
+    }
     $this->sendSuccessResponse($QUERY);
   }
   
   /**
    * @param array $QUERY
+   * @param bool $topPriority
    * @throws HTException
    */
-  private function setSupertaskPriority($QUERY) {
+  private function setSupertaskPriority($QUERY, $topPriority = false) {
     if (!isset($QUERY[UQueryTask::SUPERTASK_ID]) || !isset($QUERY[UQueryTask::SUPERTASK_PRIORITY])) {
       throw new HTException("Invalid query!");
     }
-    TaskUtils::setSupertaskPriority($QUERY[UQueryTask::SUPERTASK_ID], $QUERY[UQueryTask::SUPERTASK_PRIORITY], $this->user);
+    if ($topPriority) {
+      TaskUtils::setSupertaskPriority($QUERY[UQueryTask::SUPERTASK_ID], -1, $this->user, true);
+    }
+    else {
+      if (!isset($QUERY[UQueryTask::SUPERTASK_PRIORITY])) {
+        throw new HTException("Invalid query!");
+      }
+      TaskUtils::setSupertaskPriority($QUERY[UQueryTask::SUPERTASK_ID], $QUERY[UQueryTask::SUPERTASK_PRIORITY], $this->user);
+    }
     $this->sendSuccessResponse($QUERY);
   }
   

--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -292,15 +292,46 @@ class TaskUtils {
    * @param User $user
    * @throws HTException
    */
-  public static function setSupertaskPriority($supertaskId, $priority, $user) {
-    $supertask = Factory::getTaskWrapperFactory()->get($supertaskId);
-    if ($supertask === null) {
+  public static function setSupertaskPriority($supertaskId, $priority, $user, $topPriority = false) {
+    $supertask = TaskUtils::getTask($supertaskId, $user);
+    $supertaskWrapper = TaskUtils::getTaskWrapper($supertask->getTaskWrapperId(), $user);
+    if ($supertaskWrapper === null) {
       throw new HTException("Invalid supertask!");
     }
-    else if (!AccessUtils::userCanAccessTask($supertask, $user)) {
+    else if (!AccessUtils::userCanAccessTask($supertaskWrapper, $user)) {
       throw new HTException("No access to this task!");
     }
-    Factory::getTaskWrapperFactory()->set($supertask, TaskWrapper::PRIORITY, ($priority < 0) ? 0 : $priority);
+    $priority = self::getIntegerPriorityValue($priority, $topPriority, $user, $supertaskWrapper);
+    Factory::getTaskWrapperFactory()->set($supertaskWrapper, TaskWrapper::PRIORITY, $priority);
+  }
+  
+  /**
+   * @param int $priority
+   * @param bool $topPriority
+   * @param $user
+   * @param $taskWrapper
+   * @return int
+   */
+  public static function getIntegerPriorityValue($priority, $topPriority, $user, $taskWrapper) {
+    if ($topPriority) {
+      // determine the current highest priority of all tasks this user has access to
+      $auxTaskWrappers = TaskUtils::getTaskWrappersForUser($user);
+      $highestPriority = 0;
+      foreach ($auxTaskWrappers as $auxTaskWrapper) {
+        if ($auxTaskWrapper != $taskWrapper) {
+          if ($auxTaskWrapper->getPriority() > $highestPriority) {
+            $highestPriority = $auxTaskWrapper->getPriority();
+          }
+        }
+      }
+      // set task priority to the current highest priority plus one hundred
+      $priority = $highestPriority + 100;
+    }
+    else {
+      $priority = intval($priority);
+      $priority = ($priority < 0) ? 0 : $priority;
+    }
+    return $priority;
   }
   
   /**
@@ -579,14 +610,14 @@ class TaskUtils {
    * @param int $taskId
    * @param int $priority
    * @param User $user
+   * @param bool $top
    * @throws HTException
    */
-  public static function updatePriority($taskId, $priority, $user) {
+  public static function updatePriority($taskId, $priority, $user, $topPriority = false) {
     // change task priority
     $task = TaskUtils::getTask($taskId, $user);
     $taskWrapper = TaskUtils::getTaskWrapper($task->getTaskWrapperId(), $user);
-    $priority = intval($priority);
-    $priority = ($priority < 0) ? 0 : $priority;
+    $priority = self::getIntegerPriorityValue($priority, $topPriority, $user, $taskWrapper);
     Factory::getTaskFactory()->set($task, Task::PRIORITY, $priority);
     if ($taskWrapper->getTaskType() != DTaskTypes::SUPERTASK) {
       Factory::getTaskWrapperFactory()->set($taskWrapper, TaskWrapper::PRIORITY, $priority);


### PR DESCRIPTION
Allow to set priority of tasks and supertasks to top priority within the set of pretasks. When setting the a task to be top priority, add one hundred to the previous highest priority and use this value.

Set task to top priority - protocol
```
 The clients sets a task to top priority.

 {
     "section": "task",
     "request": "setTaskTopPriority",
     "taskId": "1",
     "accessKey": <myKey>
 }

 The server should reply following on success:

 {
     "section": "task",
     "request": "setTaskTopPriority",
     "response": "OK"
 }
```
Set supertask to top priority - protocol
```
The clients sets a supertask to top priority.

{
    "section": "task",
    "request": "setSupertaskTopPriority",
    "supertaskId": "1",
    "accessKey": <myKey>
}

The server should reply following on success:

{
    "section": "task",
    "request": "setSupertaskTopPriority",
    "response": "OK"
}
```