### PR TITLE
Users should not be able to view tasks with hashlists in other access groups

### DIFF
--- a/src/tasks.php
+++ b/src/tasks.php
@@ -74,6 +74,10 @@ if (isset($_GET['id'])) {
   }
   
   $hashlist = Factory::getHashlistFactory()->get($taskWrapper->getHashlistId());
+  if (!AccessUtils::userCanAccessHashlists($hashlist, Login::getInstance()->getUser())) {
+    UI::printError("ERROR", "No access to this task!");
+  }
+
   UI::add('hashlist', $hashlist);
   $hashtype = Factory::getHashTypeFactory()->get($hashlist->getHashtypeId());
   UI::add('hashtype', $hashtype);


### PR DESCRIPTION

Fixes #662 

The code checked if all files in the task belongs to access groups that the user belongs to, but did not check if the user was allowed to view the hashlist. Added that check now.