### PR TITLE
Issues/674 permission for managing access groups

### DIFF
--- a/doc/user-api/sections/access.tex
+++ b/doc/user-api/sections/access.tex
@@ -79,7 +79,8 @@
     "addFileAccess": false,
     "crackerBinaryAccess": false,
     "serverConfigAccess": false,
-    "userConfigAccess": false
+    "userConfigAccess": false,
+		"manageAccessGroupAccess": false
   },
   "members": [
     2,

--- a/src/inc/defines/accessControl.php
+++ b/src/inc/defines/accessControl.php
@@ -25,6 +25,7 @@ class DAccessControl {
   const CRACKER_BINARY_ACCESS       = "crackerBinaryAccess";
   const SERVER_CONFIG_ACCESS        = "serverConfigAccess";
   const USER_CONFIG_ACCESS          = "userConfigAccess";
+  const MANAGE_ACCESS_GROUP_ACCESS  = "manageAccessGroupAccess";
   
   // special access definitions for public access pages and pages which are viewable if logged in
   const PUBLIC_ACCESS = "publicAccess";
@@ -99,6 +100,8 @@ class DAccessControl {
         return "Can view preconfigured supertasks<br>Also granted with manage/create supertasks permission.";
       case DAccessControl::MANAGE_SUPERTASK_ACCESS:
         return "Can manage preconfigured supertasks.";
+      case DAccessControl::MANAGE_ACCESS_GROUP_ACCESS:
+        return "Can manage access groups.";
     }
     return "__" . $access . "__";
   }
@@ -121,7 +124,7 @@ class DViewControl {
   const FORGOT_VIEW_PERM         = DAccessControl::PUBLIC_ACCESS;
   const GETFILE_VIEW_PERM        = DAccessControl::PUBLIC_ACCESS;
   const GETHASHLIST_VIEW_PERM    = DAccessControl::PUBLIC_ACCESS;
-  const GROUPS_VIEW_PERM         = DAccessControl::USER_CONFIG_ACCESS;
+  const GROUPS_VIEW_PERM         = DAccessControl::MANAGE_ACCESS_GROUP_ACCESS;
   const HASHES_VIEW_PERM         = DAccessControl::VIEW_HASHES_ACCESS;
   const HASHLISTS_VIEW_PERM      = DAccessControl::VIEW_HASHLIST_ACCESS;
   const HASHTYPES_VIEW_PERM      = DAccessControl::SERVER_CONFIG_ACCESS;
@@ -144,10 +147,10 @@ class DViewControl {
 
 class DAccessControlAction {
   const CREATE_GROUP      = "createGroup";
-  const CREATE_GROUP_PERM = DAccessControl::USER_CONFIG_ACCESS;
+  const CREATE_GROUP_PERM = DAccessControl::MANAGE_ACCESS_GROUP_ACCESS;
   
   const DELETE_GROUP      = "deleteGroup";
-  const DELETE_GROUP_PERM = DAccessControl::USER_CONFIG_ACCESS;
+  const DELETE_GROUP_PERM = DAccessControl::MANAGE_ACCESS_GROUP_ACCESS;
   
   const EDIT      = "edit";
   const EDIT_PERM = DAccessControl::USER_CONFIG_ACCESS;

--- a/src/inc/defines/accessGroups.php
+++ b/src/inc/defines/accessGroups.php
@@ -12,20 +12,20 @@ class DAccessLevel {
 
 class DAccessGroupAction {
   const CREATE_GROUP      = "createGroup";
-  const CREATE_GROUP_PERM = DAccessControl::USER_CONFIG_ACCESS;
+  const CREATE_GROUP_PERM = DAccessControl::MANAGE_ACCESS_GROUP_ACCESS;
   
   const DELETE_GROUP      = "deleteGroup";
-  const DELETE_GROUP_PERM = DAccessControl::USER_CONFIG_ACCESS;
+  const DELETE_GROUP_PERM = DAccessControl::MANAGE_ACCESS_GROUP_ACCESS;
   
   const REMOVE_USER      = "removeUser";
-  const REMOVE_USER_PERM = DAccessControl::USER_CONFIG_ACCESS;
+  const REMOVE_USER_PERM = DAccessControl::MANAGE_ACCESS_GROUP_ACCESS;
   
   const REMOVE_AGENT      = "removeAgent";
-  const REMOVE_AGENT_PERM = DAccessControl::USER_CONFIG_ACCESS;
+  const REMOVE_AGENT_PERM = DAccessControl::MANAGE_ACCESS_GROUP_ACCESS;
   
   const ADD_USER      = "addUser";
-  const ADD_USER_PERM = DAccessControl::USER_CONFIG_ACCESS;
+  const ADD_USER_PERM = DAccessControl::MANAGE_ACCESS_GROUP_ACCESS;
   
   const ADD_AGENT      = "addAgent";
-  const ADD_AGENT_PERM = DAccessControl::USER_CONFIG_ACCESS;
+  const ADD_AGENT_PERM = DAccessControl::MANAGE_ACCESS_GROUP_ACCESS;
 }

--- a/src/templates/struct/menu.template.html
+++ b/src/templates/struct/menu.template.html
@@ -105,14 +105,18 @@
 					</div>
 				</li>
             {{ENDIF}}
-            {{IF [[accessControl.hasPermission([[$DAccessControl::USER_CONFIG_ACCESS]])]]}}
+            {{IF [[accessControl.hasPermission([[$DAccessControl::USER_CONFIG_ACCESS]])]] || [[accessControl.hasPermission([[$DAccessControl::MANAGE_ACCESS_GROUP_ACCESS]])]]}}
 				<li class="nav-item dropdown[[menu.isActive('users', 'classonly')]]"><a href="#" class="nav-link dropdown-toggle" id="dropdownUsers" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Users <span class="caret"></span></a>
 					<div class="dropdown-menu" aria-labelledby="dropdownUsers">
-						<a class="dropdown-item[[menu.isActive('users_list')]]" href="users.php">All users</a>
-						<a class="dropdown-item[[menu.isActive('users_new')]]" href="users.php?new=true">New User</a>
-						<a class="dropdown-item[[menu.isActive('users_access')]]" href="access.php">Access Management</a>
-						<a class="dropdown-item[[menu.isActive('users_api')]]" href="api.php">API Management</a>
-						<a class="dropdown-item[[menu.isActive('users_groups')]]" href="groups.php">Groups</a>
+						{{IF [[accessControl.hasPermission([[$DAccessControl::USER_CONFIG_ACCESS]])]]}}
+  						<a class="dropdown-item[[menu.isActive('users_list')]]" href="users.php">All users</a>
+	  					<a class="dropdown-item[[menu.isActive('users_new')]]" href="users.php?new=true">New User</a>
+		  				<a class="dropdown-item[[menu.isActive('users_access')]]" href="access.php">Access Management</a>
+			  			<a class="dropdown-item[[menu.isActive('users_api')]]" href="api.php">API Management</a>
+						{{ENDIF}}
+						{{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_ACCESS_GROUP_ACCESS]])]]}}
+  						<a class="dropdown-item[[menu.isActive('users_groups')]]" href="groups.php">Groups</a>
+						{{ENDIF}}
 					</div>
 				</li>
 			{{ENDIF}}


### PR DESCRIPTION
Fixes #674 

The _Users_ menu will be visible if the user has _Can manage users_ and/or _Can manage access groups_ permissions.