### PR TITLE
Enhancement/agentstatus data values

### DIFF
--- a/src/agentStatus.php
+++ b/src/agentStatus.php
@@ -94,7 +94,7 @@ $agentAssignments = new DataSet();
 $agents = Factory::getAgentFactory()->filter([Factory::FILTER => $qF, Factory::ORDER => $oF]);
 foreach ($agents as $agent) {
   $qF1 = new QueryFilter(Chunk::AGENT_ID, $agent->getId(), "=");
-  $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::STATUS_TIMER) * 2, "=");
+  $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::STATUS_TIMER) * 2, ">");
   $qF3 = new QueryFilter(Chunk::SPEED, 0, ">");
   $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2, $qF3]]);
   foreach ($chunks as $chunk) {

--- a/src/agentStatus.php
+++ b/src/agentStatus.php
@@ -94,9 +94,8 @@ $agentAssignments = new DataSet();
 $agents = Factory::getAgentFactory()->filter([Factory::FILTER => $qF, Factory::ORDER => $oF]);
 foreach ($agents as $agent) {
   $qF1 = new QueryFilter(Chunk::AGENT_ID, $agent->getId(), "=");
-  $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::STATUS_TIMER) * 2, ">");
-  $qF3 = new QueryFilter(Chunk::SPEED, 0, ">");
-  $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2, $qF3]]);
+  $qF2 = new QueryFilter(Chunk::SPEED, 0, ">");
+  $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
   foreach ($chunks as $chunk) {
     $agentTasks->addValue($agent->getId(), $chunk->getTaskId());
     $agentSpeeds->addValue($agent->getId(), $chunk->getSpeed());

--- a/src/inc/utils/AgentUtils.class.php
+++ b/src/inc/utils/AgentUtils.class.php
@@ -135,7 +135,7 @@ class AgentUtils {
       $sum += $u;
     }
     $avg = $sum / sizeof($deviceUtil);
-    return $avg."%";
+    return round($avg, 1)."%";
   }
 
   /**
@@ -176,7 +176,7 @@ class AgentUtils {
       $sum += $u;
     }
     $avg = $sum / sizeof($cpuUtil);
-    return $avg."%";
+    return round($avg, 1)."%";
   }
 
   /**

--- a/src/inc/utils/AgentUtils.class.php
+++ b/src/inc/utils/AgentUtils.class.php
@@ -118,6 +118,68 @@ class AgentUtils {
   }
 
   /**
+   * @param AgentStat $deviceUtil
+   * @return string
+   */
+  public static function getDeviceUtilStatusValue($deviceUtil) {
+    if ($deviceUtil === false) {
+      return "No data";
+    }
+    $deviceUtil = $deviceUtil->getValue();
+    if ($deviceUtil === false) {
+      return "No valid data";
+    }
+    $deviceUtil = explode(",", $deviceUtil);
+    $sum = 0;
+    foreach ($deviceUtil as $u) {
+      $sum += $u;
+    }
+    $avg = $sum / sizeof($deviceUtil);
+    return $avg."%";
+  }
+
+  /**
+   * @param AgentStat $deviceTemp
+   * @return string
+   */
+  public static function getDeviceTempStatusValue($deviceTemp) {
+    if ($deviceTemp === false) {
+      return 'No data';
+    }
+    $deviceTemp = $deviceTemp->getValue();
+    if ($deviceTemp === false) {
+      return 'No valid data';
+    }
+    $deviceTemp = explode(",", $deviceTemp);
+    $max = 0;
+    foreach ($deviceTemp as $t) {
+      $max = ($t > $max) ? $t : $max;
+    }
+    return strval($max)."°";
+  }
+
+  /**
+   * @param AgentStat $cpuUtil
+   * @return string
+   */
+  public static function getCpuUtilStatusValue($cpuUtil) {
+    if ($cpuUtil === false) {
+      return "No data";
+    }
+    $cpuUtil = $cpuUtil->getValue();
+    if ($cpuUtil === false) {
+      return "No valid data";
+    }
+    $cpuUtil = explode(",", $cpuUtil);
+    $sum = 0;
+    foreach ($cpuUtil as $u) {
+      $sum += $u;
+    }
+    $avg = $sum / sizeof($cpuUtil);
+    return $avg."%";
+  }
+
+  /**
    * @param Agent $agent
    * @param mixed $types
    * @return array

--- a/src/templates/agents/status.template.html
+++ b/src/templates/agents/status.template.html
@@ -3,12 +3,14 @@
 <h2>Agents status ([[sizeof([[agents]])]])</h2>
 {%TEMPLATE->struct/messages%}
 <hr>
-<h3>Average Device utilisation</h3>
+<h3>Average device utilisation</h3>
 <div class="container-fluid">
   <div class="row">
     {{FOREACH agent;[[agents]]}}
       <div class="col-lg-1 col-md-2 col-sm-3 col-4 text-center" style="background-color: [[AgentUtils::getDeviceUtilStatusColor([[deviceStats.getVal([[agent.getId()]])]], [[agent]])]]; border: 1px solid #808080;">
+        <i style="color:black;font-size:12px">ID: [[agent.getId()]] <br /></i>
         <a href="agents.php?id=[[agent.getId()]]" class="btn btn-light my-1" data-toggle="tooltip" data-placement="top" title="View Agent ([[agent.getAgentName()]])"><i class="fas fa-eye" aria-hidden="true"></i></a>
+        <i style="color:black;font-size:12px"><br />[[AgentUtils::getDeviceUtilStatusValue([[deviceStats.getVal([[agent.getId()]])]])]] <br /></i>
       </div>
     {{ENDFOREACH}}
   </div>
@@ -34,24 +36,26 @@
   </div>
 </div>
 <hr>
-<h3>Highest Device Temperature</h3>
+<h3>Highest device temperature</h3>
 <div class="container-fluid">
   <div class="row">
     {{FOREACH agent;[[agents]]}}
     <div class="col-lg-1 col-md-2 col-sm-3 col-4 text-center" style="background-color: [[AgentUtils::getDeviceTempStatusColor([[deviceTemps.getVal([[agent.getId()]])]], [[agent]])]]; border: 1px solid #808080;">
+      <i style="color:black;font-size:12px">ID: [[agent.getId()]] <br /></i>
       <a href="agents.php?id=[[agent.getId()]]" class="btn btn-light my-1" data-toggle="tooltip" data-placement="top" title="View Agent ([[agent.getAgentName()]])"><i class="fas fa-eye" aria-hidden="true"></i></a>
+      <i style="color:black;font-size:12px"><br />[[AgentUtils::getDeviceTempStatusValue([[deviceTemps.getVal([[agent.getId()]])]])]] <br /></i>
     </div>
     {{ENDFOREACH}}
   </div>
   <div class="row">
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #009933;">■</span> Device Temperatures good (<= [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_1]])]]°C)
+      <span style="color: #009933;">■</span> Device temperatures good (<= [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_1]])]]°C)
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #ff9900;">■</span> Device Temperatures acceptable (<= [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_2]])]]°C)
+      <span style="color: #ff9900;">■</span> Device temperatures acceptable (<= [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_2]])]]°C)
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
-      <span style="color: #800000;">■</span> Device Temperatures too high (> [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_2]])]]°C)
+      <span style="color: #800000;">■</span> Device temperatures too high (> [[config.getVal([[$DConfig::AGENT_TEMP_THRESHOLD_2]])]]°C)
     </div>
     <div class="col-lg-2 col-md-4 col-sm-12">
       <span style="color: #CCCCCC;">■</span> Agent is not active
@@ -70,7 +74,9 @@
   <div class="row">
     {{FOREACH agent;[[agents]]}}
       <div class="col-lg-1 col-md-2 col-sm-3 col-4 text-center" style="background-color: [[AgentUtils::getCpuUtilStatusColor([[cpuStats.getVal([[agent.getId()]])]], [[agent]])]]; border: 1px solid #808080;">
+        <i style="color:black;font-size:12px">ID: [[agent.getId()]] <br /></i>
         <a href="agents.php?id=[[agent.getId()]]" class="btn btn-light my-1" data-toggle="tooltip" data-placement="top" title="View Agent ([[agent.getAgentName()]])"><i class="fas fa-eye" aria-hidden="true"></i></a>
+        <i style="color:black;font-size:12px"><br />[[AgentUtils::getCpuUtilStatusValue([[cpuStats.getVal([[agent.getId()]])]])]] <br /></i>
       </div>
     {{ENDFOREACH}}
   </div>


### PR DESCRIPTION
Show explicit data values for temperature and device/cpu utilisation per agent on agentstatus overview page
Previously only the color coding was shown, which holds less information.

Small bugfix: for assignments table on agentstatus page, remove redundant filter on chunk speeds to be added because statustimer is now variable