### PR TITLE
Add supertask runtime estimation

### DIFF
--- a/src/dba/models/File.class.php
+++ b/src/dba/models/File.class.php
@@ -9,14 +9,16 @@ class File extends AbstractModel {
   private $isSecret;
   private $fileType;
   private $accessGroupId;
+  private $lineCount;
   
-  function __construct($fileId, $filename, $size, $isSecret, $fileType, $accessGroupId) {
+  function __construct($fileId, $filename, $size, $isSecret, $fileType, $accessGroupId, $lineCount) {
     $this->fileId = $fileId;
     $this->filename = $filename;
     $this->size = $size;
     $this->isSecret = $isSecret;
     $this->fileType = $fileType;
     $this->accessGroupId = $accessGroupId;
+    $this->lineCount = $lineCount;
   }
   
   function getKeyValueDict() {
@@ -27,6 +29,7 @@ class File extends AbstractModel {
     $dict['isSecret'] = $this->isSecret;
     $dict['fileType'] = $this->fileType;
     $dict['accessGroupId'] = $this->accessGroupId;
+    $dict['lineCount'] = $this->lineCount;
     
     return $dict;
   }
@@ -94,6 +97,15 @@ class File extends AbstractModel {
   function setAccessGroupId($accessGroupId) {
     $this->accessGroupId = $accessGroupId;
   }
+
+  function getLineCount() {
+    return $this->lineCount;
+  }
+  
+  function setLineCount($lineCount) {
+    $this->lineCount = $lineCount;
+  }
+  
   
   const FILE_ID = "fileId";
   const FILENAME = "filename";
@@ -101,4 +113,5 @@ class File extends AbstractModel {
   const IS_SECRET = "isSecret";
   const FILE_TYPE = "fileType";
   const ACCESS_GROUP_ID = "accessGroupId";
+  const LINE_COUNT = "lineCount";
 }

--- a/src/dba/models/FileFactory.class.php
+++ b/src/dba/models/FileFactory.class.php
@@ -23,7 +23,7 @@ class FileFactory extends AbstractModelFactory {
    * @return File
    */
   function getNullObject() {
-    $o = new File(-1, null, null, null, null, null);
+    $o = new File(-1, null, null, null, null, null, null);
     return $o;
   }
   
@@ -33,7 +33,7 @@ class FileFactory extends AbstractModelFactory {
    * @return File
    */
   function createObjectFromDict($pk, $dict) {
-    $o = new File($dict['fileId'], $dict['filename'], $dict['size'], $dict['isSecret'], $dict['fileType'], $dict['accessGroupId']);
+    $o = new File($dict['fileId'], $dict['filename'], $dict['size'], $dict['isSecret'], $dict['fileType'], $dict['accessGroupId'], $dict['lineCount']);
     return $o;
   }
   

--- a/src/inc/defines/files.php
+++ b/src/inc/defines/files.php
@@ -19,4 +19,7 @@ class DFileAction {
   
   const EDIT_FILE      = "editFile";
   const EDIT_FILE_PERM = DAccessControl::MANAGE_FILE_ACCESS;
+  
+  const COUNT_FILE_LINES      = "countFileLines";
+  const COUNT_FILE_LINES_PERM = DAccessControl::MANAGE_FILE_ACCESS;
 }

--- a/src/inc/defines/tasks.php
+++ b/src/inc/defines/tasks.php
@@ -55,6 +55,12 @@ class DSupertaskAction {
   
   const BULK_SUPERTASK      = "bulkSupertaskCreation";
   const BULK_SUPERTASK_PERM = DAccessControl::CREATE_SUPERTASK_ACCESS;
+  
+  const REMOVE_PRETASK_FROM_SUPERTASK      = "removePretaskFromSupertask";
+  const REMOVE_PRETASK_FROM_SUPERTASK_PERM = DAccessControl::CREATE_SUPERTASK_ACCESS;
+  
+  const ADD_PRETASK_TO_SUPERTASK      = "addPretaskToSupertask";
+  const ADD_PRETASK_TO_SUPERTASK_PERM = DAccessControl::CREATE_SUPERTASK_ACCESS;
 }
 
 class DTaskAction {

--- a/src/inc/handlers/FileHandler.class.php
+++ b/src/inc/handlers/FileHandler.class.php
@@ -27,6 +27,11 @@ class FileHandler implements Handler {
           FileUtils::saveChanges($_POST['fileId'], $_POST['filename'], $_POST['accessGroupId'], AccessControl::getInstance()->getUser());
           FileUtils::setFileType($_POST['fileId'], $_POST['filetype'], AccessControl::getInstance()->getUser());
           break;
+        case DFileAction::COUNT_FILE_LINES:
+          AccessControl::getInstance()->checkPermission(DFileAction::COUNT_FILE_LINES_PERM);
+          FileUtils::fileCountLines($_POST['file']);
+          UI::addMessage(UI::SUCCESS, "Line count has been successfully calculated!");
+          break;
         default:
           UI::addMessage(UI::ERROR, "Invalid action!");
           break;

--- a/src/inc/handlers/SupertaskHandler.class.php
+++ b/src/inc/handlers/SupertaskHandler.class.php
@@ -29,6 +29,14 @@ class SupertaskHandler implements Handler {
           AccessControl::getInstance()->checkPermission(DSupertaskAction::BULK_SUPERTASK_PERM);
           SupertaskUtils::bulkSupertask($_POST['name'], $_POST['command'], $_POST['isCpu'], $_POST['isSmall'], $_POST['crackerBinaryTypeId'], $_POST['benchtype'], @$_POST['basefile'], @$_POST['iterfile'], Login::getInstance()->getUser());
           break;
+        case DSupertaskAction::REMOVE_PRETASK_FROM_SUPERTASK:
+          AccessControl::getInstance()->checkPermission(DSupertaskAction::REMOVE_PRETASK_FROM_SUPERTASK_PERM);
+          SupertaskUtils::removePretaskFromSupertask($_POST['supertaskId'], $_POST['pretaskId']);
+          break;
+        case DSupertaskAction::ADD_PRETASK_TO_SUPERTASK:
+          AccessControl::getInstance()->checkPermission(DSupertaskAction::ADD_PRETASK_TO_SUPERTASK_PERM);
+          SupertaskUtils::addPretaskToSupertask($_POST['supertaskId'], $_POST['pretaskId']);
+          break;
         default:
           UI::addMessage(UI::ERROR, "Invalid action!");
           break;

--- a/src/inc/utils/FileUtils.class.php
+++ b/src/inc/utils/FileUtils.class.php
@@ -338,4 +338,30 @@ class FileUtils {
     }
     return $file;
   }
+  
+  /**
+   * @param $fileId
+   * @throws HTException
+   */
+  public static function fileCountLines($fileId) {
+    $file = Factory::getFileFactory()->get($fileId);
+    $fileName = $file->getFilename();
+    $filePath = dirname(__FILE__) . "/../../files/" . $fileName;
+    if (!file_exists($filePath)) {
+      throw new HTException("File not found!");
+    }
+    if ($file->getFileType() == 1) {
+      $count = Util::rulefileLineCount($filePath);
+    }
+    else {
+      $count = Util::fileLineCount($filePath);
+    }
+    
+    if ($count == -1) {
+      throw new HTException("Could not determine line count.");
+    }
+    else {
+      Factory::getFileFactory()->set($file, File::LINE_COUNT, $count);
+    }
+  }
 }

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -208,7 +208,7 @@ class HashlistUtils {
     fclose($wordlistFile);
     
     //add file to files list
-    $file = new File(null, $wordlistName, Util::filesize($wordlistFilename), $hashlist->getIsSecret(), 0, $hashlist->getAccessGroupId());
+    $file = new File(null, $wordlistName, Util::filesize($wordlistFilename), $hashlist->getIsSecret(), 0, $hashlist->getAccessGroupId(), null);
     Factory::getFileFactory()->save($file);
     return [$wordCount, $wordlistName, $file];
   }
@@ -674,7 +674,7 @@ class HashlistUtils {
     fclose($file);
     usleep(1000000);
     
-    $file = new File(null, $tmpname, Util::filesize($tmpfile), $hashlist->getIsSecret(), 0, $hashlist->getAccessGroupId());
+    $file = new File(null, $tmpname, Util::filesize($tmpfile), $hashlist->getIsSecret(), 0, $hashlist->getAccessGroupId(), null);
     $file = Factory::getFileFactory()->save($file);
     return $file;
   }
@@ -759,6 +759,7 @@ class HashlistUtils {
       Factory::getAgentFactory()->getDB()->rollback();
       throw new HTException("Required file does not exist!");
     }
+    // TODO: replace countLines with fileLineCount? Seems like a better option, not OS-dependent
     else if (Util::countLines($tmpfile) > SConfig::getInstance()->getVal(DConfig::MAX_HASHLIST_SIZE)) {
       Factory::getAgentFactory()->getDB()->rollback();
       throw new HTException("Hashlist has too many lines!");
@@ -1047,7 +1048,7 @@ class HashlistUtils {
     fclose($file);
     usleep(1000000);
     
-    $file = new File(null, $tmpname, Util::filesize($tmpfile), $hashlist->getIsSecret(), 0, $hashlist->getAccessGroupId());
+    $file = new File(null, $tmpname, Util::filesize($tmpfile), $hashlist->getIsSecret(), 0, $hashlist->getAccessGroupId(), null);
     return Factory::getFileFactory()->save($file);
   }
   

--- a/src/inc/utils/SupertaskUtils.class.php
+++ b/src/inc/utils/SupertaskUtils.class.php
@@ -463,4 +463,38 @@ class SupertaskUtils {
       $masks[$i] = $mask;
     }
   }
+  
+  /**
+   * @param $supertaskId
+   * @param $pretaskId
+   * @throws HTException
+   */
+  public static function removePretaskFromSupertask($supertaskId, $pretaskId) {
+    if ($supertaskId == null) {
+      throw new HTException("Invalid supertask ID!");
+    }
+    if ($pretaskId == null) {
+      throw new HTException("Invalid pretask ID!");
+    }
+    $qF1 = new QueryFilter(SupertaskPretask::SUPERTASK_ID, $supertaskId, "=");
+    $qF2 = new QueryFilter(SupertaskPretask::PRETASK_ID, $pretaskId, "=");
+    $supertaskPretask = Factory::getSupertaskPretaskFactory()->filter([Factory::FILTER => [$qF1, $qF2]], true);
+    Factory::getSupertaskPretaskFactory()->delete($supertaskPretask);
+  }
+  
+  /**
+   * @param $supertaskId
+   * @param $pretaskId
+   * @throws HTException
+   */
+  public static function addPretaskToSupertask($supertaskId, $pretaskId) {
+    if ($supertaskId == null) {
+      throw new HTException("Invalid supertask ID!");
+    }
+    if ($pretaskId == null) {
+      throw new HTException("Invalid pretask ID!");
+    }
+    $supertaskPretask = new SupertaskPretask(null, $supertaskId, $pretaskId);
+    Factory::getSupertaskPretaskFactory()->save($supertaskPretask);
+  }
 }

--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -799,6 +799,7 @@ class TaskUtils {
   public static function splitByRules($task, $taskWrapper, $files, $splitFile, $split) {
     // calculate how much we need to split
     $numSplits = floor($split[1] / 1000 / $task->getChunkTime());
+    // TODO: replace countLines with fileLineCount? Could be a better option: not OS-dependent
     $numLines = Util::countLines(dirname(__FILE__) . "/../../files/" . $splitFile->getFilename());
     $linesPerFile = floor($numLines / $numSplits) + 1;
     

--- a/src/install/updates/update_v0.12.x_v0.x.x.php
+++ b/src/install/updates/update_v0.12.x_v0.x.x.php
@@ -82,3 +82,7 @@ if (!isset($PRESENT["v0.12.x_agentBinariesUpdateTrack"])) {
   $EXECUTED["v0.12.x_agentBinariesUpdateTrack"] = true;
 }
 
+if (!isset($PRESENT["v0.12.x_fileLineCount"])) {
+  Factory::getFileFactory()->getDB()->query("ALTER TABLE `File` ADD `lineCount` INT NULL;");
+  $EXECUTED["v0.12.x_fileLineCount"] = true;
+}

--- a/src/static/optparse.1.1.1.js
+++ b/src/static/optparse.1.1.1.js
@@ -1,0 +1,357 @@
+//  Optparse.js 1.1.1 - Option Parser for Javascript
+//
+//  Copyright (c) 2009 Johan Dahlberg
+//  Copyright (c) 2020 Raptor K
+//
+//  Released under a MIT-style license.
+//
+var optparse = {};
+(function(self) {
+var VERSION = '1.1.1';
+var LONG_SWITCH_RE = /^--\w/;
+var SHORT_SWITCH_RE = /^-\w/;
+var NUMBER_RE = /^(0x[A-Fa-f0-9]+)|([0-9]+\.[0-9]+)|(\d+)$/;
+var DATE_RE = /^\d{4}-(0[0-9]|1[0,1,2])-([0,1,2][0-9]|3[0,1])$/;
+var EMAIL_RE = /^([0-9a-zA-Z]+([_.-]?[0-9a-zA-Z]+)*@[0-9a-zA-Z]+[0-9,a-z,A-Z,.,-]*(.){1}[a-zA-Z]{2,4})+$/;
+var EXT_RULE_RE = /(--[\w_-]+)\s+([\w[\]_-]+)|(--[\w_-]+)/;
+var ARG_OPTIONAL_RE = /\[(.+)\]/;
+
+// The default switch argument filter to use, when argument name doesnt match
+// any other names.
+var DEFAULT_FILTER = '_DEFAULT';
+var PREDEFINED_FILTERS = {};
+
+// The default switch argument filter. Parses the argument as text.
+function filter_text(value) {
+    return value;
+}
+
+// Switch argument filter that expects an integer, HEX or a decimal value. An
+// exception is throwed if the criteria is not matched.
+// Valid input formats are: 0xFFFFFFF, 12345 and 1234.1234
+function filter_number(value) {
+    var m = NUMBER_RE.exec(value);
+    if(m == null) throw OptError('Expected a number representative');
+    if(m[1]) {
+        // The number is in HEX format. Convert into a number, then return it
+        return parseInt(m[1], 16);
+    } else {
+        // The number is in regular- or decimal form. Just run in through
+        // the float caster.
+        return parseFloat(m[2] || m[3]);
+    }
+}
+
+// Switch argument filter that expects a Date expression. The date string MUST be
+// formated as: "yyyy-mm-dd" An exception is throwed if the criteria is not
+// matched. An DATE object is returned on success.
+function filter_date(value) {
+    var m = DATE_RE.exec(value);
+    if(m == null) throw OptError('Expected a date representation in the "yyyy-mm-dd" format.');
+    return new Date(parseInt(m[0]), parseInt(m[1]) - 1, parseInt(m[2]));
+}
+
+// Switch argument filter that expects an email address. An exception is throwed
+// if the criteria doesn't match.
+function filter_email(value) {
+    var m = EMAIL_RE.exec(value);
+    if(m == null) throw OptError('Excpeted an email address.');
+    return m[1];
+}
+
+// Switch argument filter that expects an comma-separated integer values.
+// An exception is thrown if the criteria is not matched.
+// Introduced in v1.0.9
+function filter_csv_int(value) {
+	var tokens = value.split(',');
+	for(var i = 0; i < tokens.length; i++) {
+		if(isNaN(parseInt(tokens[i]))) {
+			throw OptError('Invalid integer comma-separated value: ' + tokens[i]);
+		}
+	}
+	return value;
+}
+
+// Switch argument filter that expects an comma-separated hex values.
+// An exception is thrown if the criteria is not matched.
+// Introduced in v1.0.9
+function filter_csv_hex(value) {
+	var tokens = value.split(',');
+	for(var i = 0; i < tokens.length; i++) {
+		if(isNaN(parseInt(tokens[i], 16))) {
+			throw OptError('Invalid hex comma-separated value: ' + tokens[i]);
+		}
+	}
+	return value;
+}
+
+// Switch argument filter that expects a single character.
+// An exception is thrown if the criteria is not matched.
+// Introduced in v1.0.9
+function filter_singlechar(value) {
+	if(value.length != 1) {
+		throw OptError('Expected a single character');
+	}
+	return value;
+}
+
+// Switch argument filter that expects an integer value ranged from 0 - 100.
+// An exception is thrown if the criteria is not matched.
+// Introduced in v1.0.9
+function filter_percent(value) {
+	if(isNaN(parseInt(value))) {
+		throw OptError('Invalid percent value: ' + value);
+	} else if(parseInt(value) < 0 || parseInt(value) > 100) {
+		throw OptError('Percent out of range: ' + value);
+	}
+	return parseInt(value);
+}
+
+
+// Register all predefined filters. This dict is used by each OptionParser
+// instance, when parsing arguments. Custom filters can be added to the parser
+// instance by calling the "add_filter" -method.
+PREDEFINED_FILTERS[DEFAULT_FILTER] = filter_text;
+PREDEFINED_FILTERS['TEXT'] = filter_text;
+PREDEFINED_FILTERS['NUMBER'] = filter_number;
+PREDEFINED_FILTERS['DATE'] = filter_date;
+PREDEFINED_FILTERS['EMAIL'] = filter_email;
+PREDEFINED_FILTERS['SINGLE_CHAR'] = filter_singlechar;
+PREDEFINED_FILTERS['CSV_INT'] = filter_csv_int;
+PREDEFINED_FILTERS['CSV_HEX'] = filter_csv_hex;
+PREDEFINED_FILTERS['PERCENT'] = filter_percent;
+
+//  Buildes rules from a switches collection. The switches collection is defined
+//  when constructing a new OptionParser object.
+function build_rules(filters, arr) {
+    var rules = [];
+    for(var i=0; i<arr.length; i++) {
+        var r = arr[i], rule;
+        if(!contains_expr(r)) throw OptError('Rule MUST contain an option.');
+        switch(r.length) {
+            case 1:
+                rule = build_rule(filters, undefined, r[0]);
+                break;
+            case 2:
+                var expr = LONG_SWITCH_RE.test(r[0]) ? 0 : 1;
+                var alias = expr == 0 ? -1 : 0;
+                var desc = alias == -1 ? 1 : -1;
+                rule = build_rule(filters, r[alias], r[expr], r[desc]);
+                break;
+            case 3:
+                rule = build_rule(filters, r[0], r[1], r[2]);
+                break;
+            default:
+            case 0:
+                continue;
+        }
+        rules.push(rule);
+    }
+    return rules;
+}
+
+//  Builds a rule with specified expression, short style switch and help. This
+//  function expects a dict with filters to work correctly.
+//
+//  Return format:
+//      name               The name of the switch.
+//      short              The short style switch
+//      long               The long style switch
+//      decl               The declaration expression (the input expression)
+//      desc               The optional help section for the switch
+//      optional_arg       Indicates that switch argument is optional
+//      filter             The filter to use when parsing the arg. An
+//                         <<undefined>> value means that the switch does
+//                         not take anargument.
+function build_rule(filters, short, expr, desc) {
+    var optional, filter;
+    var m = expr.match(EXT_RULE_RE);
+    if(m == null) throw OptError('The switch is not well-formed.');
+    var long = m[1] || m[3];
+    if(m[2] != undefined) {
+        // A switch argument is expected. Check if the argument is optional,
+        // then find a filter that suites.
+        var optional = ARG_OPTIONAL_RE.test(m[2]);
+        var optional_match = m[2].match(ARG_OPTIONAL_RE);
+        var filter_name = optional ? optional_match[1] : m[2];
+        filter = filters[filter_name];
+        if(filter === undefined) filter = filters[DEFAULT_FILTER];
+    }
+    return {
+        name: long.substr(2),
+        short: short,
+        long: long,
+        decl: expr,
+        desc: desc,
+        optional_arg: optional,
+        filter: filter
+    }
+}
+
+// Loop's trough all elements of an array and check if there is valid
+// options expression within. An valid option is a token that starts
+// double dashes. E.G. --my_option
+function contains_expr(arr) {
+    if(!arr || !arr.length) return false;
+    var l = arr.length;
+    while(l-- > 0) if(LONG_SWITCH_RE.test(arr[l])) return true;
+    return false;
+}
+
+// Extends destination object with members of source object
+function extend(dest, src) {
+    var result = dest;
+    for(var n in src) {
+        result[n] = src[n];
+    }
+    return result;
+}
+
+// Appends spaces to match specified number of chars
+function spaces(arg1, arg2) {
+    var l, builder = [];
+    if(arg1.constructor === Number) {
+        l = arg1;
+    } else {
+        if(arg1.length == arg2) return arg1;
+        l = arg2 - arg1.length;
+        builder.push(arg1);
+    }
+    while(l-- > 0) builder.push(' ');
+    return builder.join('');
+}
+
+// Creates an error object with specified error message.
+function OptError(msg) {
+    return new function() {
+        this.msg = msg;
+        this.toString = function() {
+            return this.msg;
+        }
+    }
+}
+
+function OptionParser(rules) {
+    this.banner = 'Usage: [Options]';
+    this.options_title = 'Available options:'
+    this._rules = rules;
+    this._halt = false;
+    this.filters = extend({}, PREDEFINED_FILTERS);
+    this.on_args = {};
+    this.on_switches = {};
+    this.on_halt = function() {};
+    this.default_handler = function() {};
+}
+
+OptionParser.prototype = {
+
+    // Adds args and switchs handler.
+    on: function(value, fn) {
+        if(value.constructor === Function ) {
+            this.default_handler = value;
+        } else if(value.constructor === Number) {
+            this.on_args[value] = fn;
+        } else {
+            this.on_switches[value] = fn;
+        }
+    },
+
+    // Adds a custom filter to the parser. It's possible to override the
+    // default filter by passing the value "_DEFAULT" to the ´´name´´
+    // argument. The name of the filter is automatically transformed into
+    // upper case.
+    filter: function(name, fn) {
+        this.filters[name.toUpperCase()] = fn;
+    },
+
+    // Parses specified args. Returns remaining arguments.
+    parse: function(args) {
+        var result = [], callback;
+        var rules = build_rules(this.filters, this._rules);
+        var tokens = args.concat([]);
+        var token;
+        while(this._halt == false && (token = tokens.shift())) {
+            if(LONG_SWITCH_RE.test(token) || SHORT_SWITCH_RE.test(token)) {
+                var arg = undefined;
+                // The token is a long or a short switch. Get the corresponding
+                // rule, filter and handle it. Pass the switch to the default
+                // handler if no rule matched.
+                for(var i = 0; i < rules.length; i++) {
+                    var rule = rules[i];
+                    if(rule.long == token || rule.short == token) {
+                        if(rule.filter !== undefined) {
+                            arg = tokens.shift();
+                            if(arg && (!LONG_SWITCH_RE.test(arg) && !SHORT_SWITCH_RE.test(arg))) {
+                                try {
+                                    arg = rule.filter(arg, tokens);
+                                } catch(e) {
+                                    throw OptError(token + ': ' + e.toString());
+                                }
+                            } else if(rule.optional_arg) {
+                                if(arg) {
+                                    tokens.unshift(arg);
+                                }
+                            } else {
+                                throw OptError('Expected switch argument.');
+                            }
+                        }
+                        callback = this.on_switches[rule.name];
+                        if (!callback) callback = this.on_switches['*'];
+                        if(callback) callback.apply(this, [rule.name, arg]);
+                        break;
+                    }
+                }
+                if(i == rules.length) this.default_handler.apply(this, [token]);
+            } else {
+                // Did not match long or short switch. Parse the token as a
+                // normal argument.
+                callback = this.on_args[result.length];
+                result.push(token);
+                if(callback) callback.apply(this, [token]);
+            }
+        }
+        return this._halt ? this.on_halt.apply(this, [tokens]) : result;
+    },
+
+    // Returns an Array with all defined option rules
+    options: function() {
+        return build_rules(this.filters, this._rules);
+    },
+
+    // Add an on_halt callback if argument ´´fn´´ is specified. on_switch handlers can
+    // call instance.halt to abort the argument parsing. This can be useful when
+    // displaying help or version information.
+    halt: function(fn) {
+        this._halt = fn === undefined
+        if(fn) this.on_halt = fn;
+    },
+
+    // Returns a string representation of this OptionParser instance.
+    toString: function() {
+        var builder = [this.banner, '', this.options_title],
+            shorts = false, longest = 0, rule;
+        var rules = build_rules(this.filters, this._rules);
+        for(var i = 0; i < rules.length; i++) {
+            rule = rules[i];
+            // Quick-analyze the options.
+            if(rule.short) shorts = true;
+            if(rule.decl.length > longest) longest = rule.decl.length;
+        }
+        for(var i = 0; i < rules.length; i++) {
+            var text = spaces(6);
+            rule = rules[i];
+            if(shorts) {
+                if(rule.short) text = spaces(2) + rule.short + ', ';
+            }
+            text += spaces(rule.decl, longest) + spaces(3);
+            text += rule.desc;
+            builder.push(text);
+        }
+        return builder.join('\n');
+    }
+}
+
+self.VERSION = VERSION;
+self.OptionParser = OptionParser;
+
+})(optparse);

--- a/src/static/optparse.hashtopolis.1.1.1.js
+++ b/src/static/optparse.hashtopolis.1.1.1.js
@@ -1,0 +1,340 @@
+/**
+ * Hashcat Command Validation (based on Hashcat v6.1.1)
+ *
+ * This plugin provides validation of Hashcat command
+ * require OptparseJS Library: https://github.com/shivanraptor/optparse-js
+ *
+ * @package    optparse_hashtopolis
+ * @copyright  2020 Raptor Kwok
+ * @license    MIT License
+ * @website    https://github.com/shivanraptor/optparse-js
+ * @version	   0.3
+ */
+
+// TODO: Change hardcoded values to ENUM
+
+let switches = [
+	['-m', '--hash-type NUMBER', "Hash-type"],
+	['-a', '--attack-mode NUMBER', "Attack-mode"],
+	['-V', '--version', "Print version"],
+	['-h', '--help', "Print help"],
+	['--quiet', "Suppress output"],
+	['--hex-charset', "Assume charset is given in hex"],
+	['--hex-salt', "Assume salt is given in hex"],
+	['--hex-wordlist', "Assume words in wordlist are given in hex"],
+	['--force', "Ignore warnings"],
+	['--status', "Enable automatic update of the status screen"],
+	['--status-json', "Enable JSON format for status output"],
+	['--status-timer NUMBER', "Sets seconds between status screen updates to X"],
+	['--stdin-timeout-abort NUMBER', "Abort if there is no input from stdin for X seconds"],
+	['--machine-readable', "Display the status view in a machine-readable format"],
+	['--keep-guessing', "Keep guessing the hash after it has been cracked"],
+	['--self-test-disable', "Disable self-test functionality on startup"],
+	['--loopback', "Add new plains to induct directory"],
+	['--markov-hcstat2 FILE', "Specify hcstat2 file to use"],
+	['--markov-disable', "Disables markov-chains, emulates classic brute-force"],
+	['--markov-classic', "Enables classic markov-chains, no per-position"],
+	['-t', '--markov-threshold NUMBER', "Threshold X when to stop accepting new markov-chains"],
+	['--runtime NUMBER', "Abort session after X seconds of runtime"],
+	['--session MESSAGE', "Define specific session name"],
+	['--session', "Restore session from --session"], 
+	['--restore-disable', "Do not write restore file"],
+	['--restore-file-path FILE', "Specific path to restore file"],
+	['-o', '--outfile FILE', "Define outfile for recovered hash"],
+	['--outfile-format CSV_INT', "Outfile format to use, separated with commas"],
+	['--outfile-autohex-disable', "Disable the use of $HEX[] in output plains"],
+	['--outfile-check-timer NUMBER', "Sets seconds between outfile checks to X"],
+	['--wordlist-autohex-disable', "Disable the conversion of $HEX[] from the wordlist"],
+	['-p', '--separator SINGLE_CHAR', "Separator char for hashlists and outfile"],
+	['--stdout', "Do not crack a hash, instead print candidates only"],
+	['--show', "Compare hashlist with potfile; show cracked hashes"],
+	['--left', "Compare hashlist with potfile; show uncracked hashes"],
+	['--username', "Enable ignoring of usernames in hashfile"],
+	['--remove', "Enable removal of hashes once they are cracked"],
+	['--remove-timer NUMBER', "Update input hash file each X seconds"],
+	['--potfile-disable', "Do not write potfile"],
+	['--potfile-path FILE', "Specific path to potfile"],
+	['--encoding-from ENCODING', "Force internal wordlist encoding from X"],
+	['--encoding-to ENCODING', "Force internal wordlist encoding to X"],
+	['--debug-mode NUMBER', "Defines the debug mode (hybrid only by using rules)"],
+	['--debug-file FILE', "Output file for debugging rules"],
+	['--induction-dir FILE', "Specify the induction directory to use for loopback"], // TODO: Change to DIRECTORY filter
+	['--outfile-check-dir FILE', "Specify the outfile directory to monitor for plains"], // TODO: Change to DIRECTORY filter
+	['--logfile-disable', "Disable the logfile"],
+	['--hccapx-message-pair NUMBER', "Load only message pairs from hccapx matching X"],
+	['--nonce-error-corrections NUMBER', "The BF size range to replace AP's nonce last bytes"],
+	['--keyboard-layout-mapping FILE', "Keyboard layout mapping table for special hash-modes"],
+	['--truecrypt-keyfiles FILE', "TrueCrypt Keyfiles to use, separated with commas"],
+	['--veracrypt-keyfiles FILE', "VeraCrypt Keyfiles to use, separated with commas"],
+	['--veracrypt-pim-start NUMBER', "VeraCrypt personal iterations multiplier start"],
+	['--veracrypt-pim-stop NUMBER', "VeraCrypt personal iterations multiplier stop"],
+	['-b', '--benchmark', "Run benchmark of selected hash-modes"],
+	['--benchmark-all', "Run benchmark of all hash-modes (requires -b)"], // TODO: Check existence of -b flag
+	['--speed-only', "Return expected speed of the attack, then quit"],
+	['--progress-only', "Return ideal progress step size and time to process"],
+	['-c', '--segement-size NUMBER', "Sets size in MB to cache from the wordfile to X"],
+	['--bitmap-min NUMBER', "Sets minimum bits allowed for bitmaps to X"],
+	['--bitmap-max NUMBER', "Sets maximum bits allowed for bitmaps to X"], // TODO: Compare with --bitmap-min
+	['--cpu-affinity CSV_INT', "Locks to CPU devices, separated with commas"],
+	['--hook-threads NUMBER', "Sets number of threads for a hook (per compute unit)"],
+	['--example-hashes', "Show an example hash for each hash-mode"],
+	['--backend-ignore-cuda', "Do not try to open CUDA interface on startup"],
+	['--backend-ignore-opencl', "Do not try to open OpenCL interface on startup"],
+	['-I', '--backend-info', "Show info about detected backend API devices"],
+	['-d', '--backend-devices CSV_INT', "Backend devices to use, separated with commas"],
+	['-D', '--opencl-device-types CSV_INT', "OpenCL device-types to use, separated with commas"],
+	['-O', '--optimized-kernel-enable', "Enable optimized kernels (limits password length)"],
+	['-w', '--workload-profile NUMBER', "Enable a specific workload profile, see pool below"], // TODO: Check Workload Profile range
+	['-n', '--kernel-accel NUMBER', "Manual workload tuning, set outerloop step size to X"],
+	['-u', '--kernel-loops NUMBER', "Manual workload tuning, set innerloop step size to X"],
+	['-T', '--kernel-threads NUMBER', "Manual workload tuning, set thread count to X"],
+	['--backend-vector-width NUMBER', "Manually override backend vector-width to X"],
+	['--spin-damp PERCENT', "Use CPU for device synchronization, in percent"],
+	['--hwmon-disable', "Disable temperature and fanspeed reads and triggers"], 
+	['--hwmon-temp-abort NUMBER', "Abort if temperature reaches X degrees Celsius"], 
+	['--scrypt-tmto NUMBER', "Manually override TMTO value for scrypt to X"],
+	['-s', '--skip NUMBER', "Skip X words from the start"],
+	['-l', '--limit', "Limit X words from the start + skipped words"],
+	['--keyspace', "Show keyspace base:mod values and quit"],
+	['-j', '--rule-left FILE', "Single rule applied to each word from left wordlist"],
+	['-k', '--rule-right FILE', "Single rule applied to each word from right wordlist"],
+	['-r', '--rules-file FILE', "Multiple rules applied to each word from wordlists"],
+	['-g', '--generate-rules NUMBER', "Generate X random rules"],
+	['--generate-rules-func-min NUMBER', "Force min X functions per rule"],
+	['--generate-rules-func-max NUMBER', "Force max X functions per rule"], // TODO: Compare MIN and MAX values
+	['--generate-rules-seed NUMBER', "Force RNG seed set to X"],
+	['-1', '--custom-charset1 MESSAGE', "User-defined charset ?1"], // TODO: Check Charset
+	['-2', '--custom-charset2 MESSAGE', "User-defined charset ?2"], // TODO: Check Charset
+	['-3', '--custom-charset3 MESSAGE', "User-defined charset ?3"], // TODO: Check Charset
+	['-4', '--custom-charset4 MESSAGE', "User-defined charset ?4"], // TODO: Check Charset
+	['-i', '--increment', "Enable mask increment mode"],
+	['--increment-min NUMBER', "Start mask incrementing at X"],
+	['--increment-max NUMBER', "Stop mask incrementing at X"], // TODO: Compare MIN and MAX values
+	['-S', '--slow-candidates', "Enable slower (but advanced) candidate generators"],
+	['--brain-server', "Enable brain server"],
+	['--brain-server-timer NUMBER', "Update the brain server dump each X seconds (min:60)"],
+	['-z', '--brain-client', "Enable brain client, activates -S"],
+	['--brain-client-features NUMBER', "Define brain client features, see below"], // TODO: Check brain client features range
+	['--brain-host MESSAGE', "Brain server host (IP or domain)"], // TODO: Check IP or Domain format
+	['--brain-port NETWORK_PORT', "Brain server port"],
+	['--brain-password MESSAGE', "Brain server authentication password"], 
+	['--brain-session HEX', "Overrides automatically calculated brain session"],
+	['--brain-session-whitelist CSV_HEX', "Allow given sessions only, separated with commas"],
+];
+let defaultOptions = {
+	debug: false,
+	ruleFiles: [],
+	attackType: -1,
+	hashMode: -1,
+	posArgs: [], // Positional Arguments
+	customCharset1: '',
+	customCharset2: '',
+	customCharset3: '',
+	customCharset4: '',
+	unrecognizedFlag: []
+};
+var options = defaultOptions;
+
+var parser = new optparse.OptionParser(switches);
+
+// =======================================================================================
+// Custom Hashtopolis-specific Filters
+// =======================================================================================
+parser.filter('encoding', function(value) {
+	// TODO: Complete Encoding List: http://www.iana.org/assignments/character-sets
+	var encodings = ['us-ascii', 'iso-8859-1', 'iso-8859-2', 'iso-8859-3', 'iso-8859-4', 'iso-8859-5', 'iso-8859-6', 'iso-8859-7', 'iso-8859-8', 'iso-8859-9', 'iso-8859-10', 'iso_6937-2-add', 'jis_x0201', 'jis_encoding', 'shift_jis', 'bs_4730', 'sen_850200_c', 'it', 'es', 'din_66003', 'ns_4551-1', 'nf_z_62-010', 'iso-10646-utf-1', 'invariant', 'nats-sefi', 'nats-sefi-add', 'nats-dano', 'nats-dano-add', 'sen_850200_b', 'ks_c_5601-1987', 'euc-jp', 'iso-2022-kr', 'euc-kr', 'iso-2022-jp', 'iso-2022-jp-2', 'jis_c6220-1969-jp', 'jis_c6220-1969-ro', 'pt', 'greek7-old', 'latin-greek', 'latin-greek-1', 'iso-5427', 'jis_c6226-1978', 'inis', 'inis-8', 'inis-cyrillic', 'gb_1988-80', 'gb_2312-80', 'ns_4551-2', 'pt2', 'es2', 'jis_c6226-1983', 'greek7', 'asmo_449',  'iso-ir-90', 'jis_c6229-1984-a', 'jis_c6229-1984-b', 'jis_c6229-1984-b-add', 'iso_c6229-1984-hand', 'iso_c6229-1984-hand-add', 'jis_c6229-1984-kana', 'iso_2033-1983', 'ansx_x3.110-1983', 't.61-7bit', 't.61-8bit', 'ecma-cyrillic', 'csa_z243.4-1985-1', 'csa_z243.4-1985-2', 'csa_z243.4-1985-gr', 'iso-8859-6-e', 'iso-8859-6-i', 't.101-g2', 'iso-8859-8-e', 'iso-8859-8-i', 'csn_369103', 'jus_i.b1.002', 'iec_p27-1', 'greek-ccitt', 'iso_6937-2-25', 'gost_19768-74', 'iso_8859-supp', 'iso_10367-box', 'latin-lap', 'jis_x0212-1990', 'ds_2089', 'us-dk', 'dk-us', 'ksc5636', 'unicode-1-1-utf-7', 'iso-2022-cn', 'iso-2022-cn-ext', 'iso-8859-13', 'iso-8859-14', 'iso-8859-15', 'iso-8859-16', 'gbk', 'gb18030', 'gb2312', 'osd_ebcdic_df04_15', 'osd_edcdic_df03_irv', 'osd_ebcdic_df04_1', 'iso-11548-1', 'kz-1048', 'iso-10646-ucs-2', 'iso-10646-ucs-4', 'iso-10646-ucs-basic', 'iso-10646-unicode-latin1', 'iso-10646-j-1', 'iso-unicode-ibm-1261', 'iso-unicode-ibm-1268', 'iso-unicode-ibm-1276', 'iso-unicode-ibm-1264', 'iso-unicode-ibm-1265', 'unicode1-1', 'scsu', 'utf-7', 'big5', 'koi8-r', 'utf-8', 'utf-16', 'utf-16be', 'utf-16le', 'utf-32', 'utf-32be', 'utf-32le', 'cesu-8', 'bocu-1', 'hp-roman8', 'adobe-standard-encoding', 'ventura-us', 'ibm-symbols', 'adobe-symbol-encoding', 'macintosh', 'hz-gb-2312', 'windows-1258', 'tis-620', 'cp50220'];
+	if(encodings.indexOf(value) == -1) {
+		throw "Invalid encoding standards";
+	}
+	return value; 
+});
+
+parser.filter('network_port', function(value) {
+	if(parseInt(value) <= 0 || parseInt(value) > 65536) {
+		throw "Network port out of range (1 - 65536)";
+	}
+	return parseInt(value);
+});
+
+// =======================================================================================
+// Option Parser (to be completed)
+// =======================================================================================
+parser.on('hash-type', function(name, value) {
+	// console.log('Hash Type: ' + value);
+	options.hashMode = parseInt(value); // TODO: Check Hash Mode
+});
+parser.on('attack-mode', function(name, value) {
+	// console.log('Attack Mode: ' + value);
+	if(parseInt(value) >= 0 && parseInt(value) <= 9) {
+		options.attackType = parseInt(value);
+	} else {
+		throw "Invalid Attack Type";
+	}
+});
+parser.on('rules-file', function(name, value) {
+	options.ruleFiles.push(value);
+});
+parser.on('status-timer', function(name, value) {
+	// console.log('Status Timer: ' + value);
+});
+parser.on('separator', function(name, value) {
+	// console.log('Separator: ' + value);
+});
+parser.on('encoding-from', function(name, value) {
+	// console.log('Encoding From: ' + value);
+});
+parser.on('cpu-affinity', function(name, value) {
+	// console.log('CPU Affinity: ' + value);
+});
+parser.on('brain-session', function(name, value) {
+	// console.log('Brain Session: ' + value);
+});
+parser.on('brain-session-whitelist', function(name, value) {
+	// console.log('Brain Session-whitelist: ' + value);
+});
+parser.on('spin-damp', function(name, value) {
+	// console.log('Spin Damp Percent: ' + value);
+});
+parser.on('custom-charset1', function(name, value) {
+	// console.log('Custom Charset 1: ' + value);
+	options.customCharset1 = value;
+});
+parser.on('custom-charset2', function(name, value) {
+	// console.log('Custom Charset 2: ' + value);
+	options.customCharset2 = value;
+});
+parser.on('custom-charset3', function(name, value) {
+	// console.log('Custom Charset 3: ' + value);
+	options.customCharset3 = value;
+});
+parser.on('custom-charset4', function(name, value) {
+	// console.log('Custom Charset 4: ' + value);
+	options.customCharset4 = value;
+});
+parser.on('print', function(value) {
+	// console.log('PRINT: ' + value);
+});
+parser.on('debug', function() {
+	options.debug = true;
+});
+parser.on(0, function(opt) {
+	// console.log('The first non-switch option is: ' + opt);
+	options.posArgs[0] = opt;
+});
+parser.on(1, function(opt) {
+	// console.log('The second non-switch option is: ' + opt);
+	options.posArgs[1] = opt;
+});
+parser.on(2, function(opt) {
+	// console.log('The third non-switch option is: ' + opt);
+	options.posArgs[2] = opt;
+});
+parser.on(3, function(opt) {
+	// console.log('The fourth non-switch option is: ' + opt);
+	options.posArgs[3] = opt;
+});
+parser.on(4, function(opt) {
+	// console.log('The fifth non-switch option is: ' + opt);
+	options.posArgs[4] = opt;
+});
+parser.on('*', function(opt, value) {
+    // console.log('wild handler for ' + opt + ', value=' + value);
+});
+parser.on(function(opt) {
+	// console.log('Unrecognized flag: ' + opt);
+	options.unrecognizedFlag.push(opt);
+});
+
+// =======================================================================================
+// Functions
+// =======================================================================================
+function startParse(cmd, isHashtopolis = true) {
+	// resetting the options
+	options = defaultOptions;
+	options.ruleFiles = [];
+	options.posArgs = [];
+	options.unrecognizedFlag = [];
+	
+	var result = false;
+	if(isHashtopolis) {
+		args = cmd.replace('hashcat', '').trim().split(/ |=/g);
+		try {
+			parser.parse(args);
+			result = validateHashtopolisCommand(options);
+		} catch (e) {
+			return {"result": false, "reason": "Value exception: " + e};
+		}
+	} else {
+		parser.parse(args);
+		result = validateHashcatCommand(options);
+	}
+	return result;
+}
+
+function validateHashtopolisCommand(opt) {
+	// Pre-case Check
+	if(opt.posArgs[0] != '#HL#') {
+		return {"result": false, "reason": "Hashlist is missing"};
+	}
+	return validateHashcatCommand(opt);
+}
+
+function validateHashcatCommand(opt) {
+	if(opt.unrecognizedFlag.length > 0) {
+		return {"result": false, "reason": "Unrecognized Flag: " + opt.unrecognizedFlag.join(', ')};
+	} else if(opt.attackType == 0) { // 0: Word List Attack
+		// Required Dictionary
+		if(opt.posArgs.length == 2) {
+			// console.log('Dictionary: ' + opt.posArgs[1]);
+			if(opt.ruleFiles.length == 0) {
+				return {"result": true, "reason": "Word List Attack"};
+			} else {
+				return {"result": true, "reason": "Word List Attack with " +  opt.ruleFiles.length + " rule(s)."};
+			}
+		} else {
+			return {"result": false, "reason": "Missing wordlist"};
+		}
+	} else if(opt.attackType == 1) { // 1: Combinator Attack
+		// Required Left and Right Wordlist 
+		if(opt.posArgs.length == 3) {
+			// console.log('Left Wordlist: ' + opt.posArgs[1] + ', Right Wordlist: ' + opt.posArgs[2]);
+			if(opt.ruleFiles.length == 0) {
+				return {"result": true, "reason": "Combinator Attack"};
+			} else {
+				return {"result": false, "reason": "Combinator Attack cannot use with rules"};
+			}
+		} else {
+			return {"result": false, "reason": "Required TWO Wordlist"};
+		}
+	} else if(opt.attackType == 3) { // 3: Bruteforce Attack
+		if(opt.posArgs.length > 1) {
+			if(opt.customCharset1 != '') {
+				if(opt.posArgs[1].indexOf('?1') !== -1) {
+					return {"result": true, "reason": "Bruteforce Attack with Character Set 1"};
+				}
+			}
+			if(opt.customCharset2 != '') {
+				if(opt.posArgs[1].indexOf('?2') !== -1) {
+					return {"result": true, "reason": "Bruteforce Attack with Character Set 2"};
+				}
+			}
+			if(opt.customCharset3 != '') {
+				if(opt.posArgs[1].indexOf('?3') !== -1) {
+					return {"result": true, "reason": "Bruteforce Attack with Character Set 3"};
+				}
+			}
+			if(opt.customCharset4 != '') {
+				if(opt.posArgs[1].indexOf('?4') !== -1) {
+					return {"result": true, "reason": "Bruteforce Attack with Character Set 4"};
+				}
+			}
+			
+			// No custom character set
+			return {"result": true, "reason": "Bruteforce Attack with pattern: " + opt.posArgs[1]};
+		} else {
+			return {"result": false, "reason": "Bruteforce Attack but missing pattern"};
+		}
+	} else {
+		return {"result": false, "reason": "Missing / Unsupported Attack Type (Supported Types: 0, 1, 3)"};
+	}
+}

--- a/src/templates/files/index.template.html
+++ b/src/templates/files/index.template.html
@@ -35,6 +35,7 @@
                   <th>File</th>
                   <th><span class="fas fa-lock" aria-hidden="true"></span></th>
                   <th style="text-align: right">Size</th>
+                  <th style="text-align: right">Line count</th>
                   <th>Access Group</th>
                   <th>Action</th>
                 </tr>
@@ -64,6 +65,17 @@
                       </td>
                       <td class='num' data-sort="[[file.getSize()]]">
                           [[Util::nicenum([[file.getSize()]])]]B
+                      </td>
+                      <td class='num'>
+                        [[file.getLineCount()]] &nbsp;
+                        {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_FILE_ACCESS]])]]}}
+                          <form class="float-right mx-1" action="files.php?view=[[view]]" method="POST">
+                            <input type="hidden" name="action" value="[[$DFileAction::COUNT_FILE_LINES]]">
+                            <input type="hidden" name="csrf" value="[[csrf]]">
+                            <input type="hidden" name="file" value="[[file.getId()]]">
+                            <button type="submit" class='btn {{IF [[toggledarkmode]] > 0}}btn-primary{{ELSE}}btn-light{{ENDIF}}' data-toggle="tooltip" data-placement="top" title="Recount the lines in this file">✓?</button>
+                          </form>
+                        {{ENDIF}}
                       </td>
                       <td>
                         [[accessGroups.getVal([[file.getAccessGroupId()]]).getGroupName()]]

--- a/src/templates/supertasks/detail.template.html
+++ b/src/templates/supertasks/detail.template.html
@@ -3,33 +3,21 @@
 <h2>Supertask Details</h2>
 {%TEMPLATE->struct/messages%}
 {{IF ! [[supertask]]}}
-	<div class='alert alert-danger'>Invalid supertask!</div>
+  <div class='alert alert-danger'>Invalid supertask!</div>
 {{ELSE}}
-	<div class="card">
+  <div class="card">
     <div class="table-responsive">
       <table class="table table-bordered">
-			  <tr>
-				  <th>ID</th>
+        <tr>
+          <th>Supertask ID</th>
           <td>[[supertask.getId()]]</td>
         </tr>
         <tr>
-				  <th>Name</th>
+          <th>Name</th>
           <td>[[supertask.getSupertaskName()]]</td>
         </tr>
         <tr>
-				  <th>Tasks</th>
-          <td>
-            {{FOREACH task;[[tasks]]}}
-              {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_PRETASK_ACCESS]])]]}}
-                <a href="pretasks.php?id=[[task.getId()]]">[[task.getTaskName()]]</a><br>
-              {{ELSE}}
-                [[task.getTaskName()]]<br>
-              {{ENDIF}}
-            {{ENDFOREACH}}
-          </td>
-        </tr>
-        <tr>
-				  <th>Actions</th>
+          <th>Actions</th>
           <td>
             {{IF [[accessControl.hasPermission([[$DAccessControl::RUN_TASK_ACCESS]])]]}}
               <form style ='float: left; padding-right: 5px;' action="supertasks.php?new=true&id=[[supertask.getId()]]" method="post">
@@ -38,17 +26,421 @@
               </form>
             {{ENDIF}}
             {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_SUPERTASK_ACCESS]])]]}}
-              <form style ='float: left;' action="supertasks.php" method="POST" onSubmit="if (!confirm('Really delete supertasktask [[supertask.getId()]]?')) return false;">
+              <form style ='float: left;' action="supertasks.php?id=[[supertask.getId()]]" method="POST" onSubmit="if (!confirm('Really delete supertask [[supertask.getId()]]?')) return false;">
                 <input type="hidden" name="action" value="[[$DSupertaskAction::DELETE_SUPERTASK]]">
                 <input type="hidden" name="supertask" value="[[supertask.getId()]]">
                 <input type="hidden" name="csrf" value="[[csrf]]">
-                <input type="submit" class='btn btn-danger' value="X">
+                <input type="submit" class='btn btn-danger' value="Delete">
               </form>
             {{ENDIF}}
           </td>
-			  </tr>
-		  </table>
+        </tr>
+        <tr>
+          <th>
+            Estimate runtime (enter benchmarks H/s)
+          </th>
+          <td>
+            <form style ='float: left;' action="supertasks.php?id=[[supertask.getId()]]" method="POST" id="keyspaceCalculation">
+              <i>Benchmark for -a0 attacks :</i>
+              <input type="text" name="benchmarka0" class="form-control" title="Hashes per second" value=[[benchmarka0]]>
+              <i>Benchmark for -a3 attacks :</i>
+              <input type="text" name="benchmarka3" class="form-control" title="Hashes per second" value=[[benchmarka3]]>
+              <input type="submit" class='btn {{IF [[toggledarkmode]] > 0}}btn-primary{{ELSE}}btn-light{{ENDIF}}' value="Calculate runtime">
+            </form>
+          </td>
+        </tr>
+        {{IF [[benchmarka0]] != 0 AND [[benchmarka3]] != 0}}
+          <tr>
+            <th>
+              Estimated total runtime of supertask
+            </th>
+            <td class="runtimeOfSupertask">
+            </td>
+          </tr>
+        {{ENDIF}}
+      </table>
     </div>
-	</div>
+  </div>
+  <h4>Pretasks part of this supertask</h4>
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-bordered table-sm" id="pretasksOfSupertasks">
+        <thead>
+          <tr>
+            <th>Pretask ID</th>
+            <th>Name</th>
+            <th>Attack command</th>
+            <th style="display:none;">Auxiliary keyspace value</th>
+            <th>Keyspace size</th>
+            <th>Attack runtime</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{FOREACH task;[[tasks]]}}
+            <tr class="taskInSuper">
+              <td{{IF [[strlen([[task.getColor()]])]] > 0}} style="background-color: #[[task.getColor()]]"{{ENDIF}}>
+                {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_PRETASK_ACCESS]])]]}}
+                  <a href="pretasks.php?id=[[task.getId()]]">[[task.getId()]]</a><br>
+                {{ELSE}}
+                  [[task.getId()]]<br>
+                {{ENDIF}}
+              </td>
+              <td>
+                {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_PRETASK_ACCESS]])]]}}
+                  <a href="pretasks.php?id=[[task.getId()]]">[[task.getTaskName()]]</a><br>
+                {{ELSE}}
+                  [[task.getTaskName()]]<br>
+                {{ENDIF}}
+              </td>
+              <td class="attackCmd">
+                [[task.getAttackCmd()]]
+              </td>
+              <td style="display:none;">
+                [[pretaskAuxiliaryKeyspace.getVal([[task.getId()]])]]
+              </td>
+              <td class="keyspaceSize">
+              </td>
+              <td class="attackRuntime">
+              </td>
+              <td>
+                {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_SUPERTASK_ACCESS]])]]}}
+                  <form style ='float: left;' action="supertasks.php?id=[[supertask.getId()]]&benchmarka0=[[benchmarka0]]&benchmarka3=[[benchmarka3]]" method="POST" onSubmit="if (!confirm('Really remove pretask [[task.getId()]] from this supertask [[supertask.getId()]]?')) return false;">
+                    <input type="hidden" name="action" value="[[$DSupertaskAction::REMOVE_PRETASK_FROM_SUPERTASK]]">
+                    <input type="hidden" name="supertaskId" value="[[supertask.getId()]]">
+                    <input type="hidden" name="pretaskId" value="[[task.getId()]]">
+                    <input type="hidden" name="csrf" value="[[csrf]]">
+                    <input type="hidden" name="benchmarka0" value="[[benchmarka0]]">
+                    <input type="hidden" name="benchmarka3" value="[[benchmarka3]]">
+                    <input type="submit" class='btn btn-danger' value="Remove">
+                  </form>
+                {{ENDIF}}
+              </td>
+            </tr>
+          {{ENDFOREACH}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <h4>Pretasks not part of this supertask</h4>
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-bordered table-sm" id="remainingPretasks">
+      <thead>
+        <tr>
+          <th>Pretask ID</th>
+          <th>Name</th>
+          <th>Attack command</th>
+          <th style="display:none;">Auxiliary keyspace value</th>
+          <th>Keyspace size</th>
+          <th>Attack runtime</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{FOREACH pretask;[[allOtherPretasks]]}}
+          <tr class="taskNotInSuper">
+            <td{{IF [[strlen([[pretask.getColor()]])]] > 0}} style="background-color: #[[pretask.getColor()]]"{{ENDIF}}>
+              {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_PRETASK_ACCESS]])]]}}
+                <a href="pretasks.php?id=[[pretask.getId()]]">[[pretask.getId()]]</a><br>
+              {{ELSE}}
+                [[pretask.getId()]]<br>
+              {{ENDIF}}
+            </td>
+            <td>
+              {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_PRETASK_ACCESS]])]]}}
+                <a href="pretasks.php?id=[[pretask.getId()]]">[[pretask.getTaskName()]]</a><br>
+              {{ELSE}}
+                [[pretask.getTaskName()]]<br>
+              {{ENDIF}}
+            </td>
+            <td>
+              [[pretask.getAttackCmd()]]<br>
+            </td>
+            <td style="display:none;">
+              [[pretaskAuxiliaryKeyspace.getVal([[pretask.getId()]])]]
+            </td>
+            <td class="keyspaceSize">
+            </td>
+            <td class="attackRuntime">
+            </td>
+            <td>
+              {{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_SUPERTASK_ACCESS]])]]}}
+                <form style ='float: left;' action="supertasks.php?id=[[supertask.getId()]]&benchmarka0=[[benchmarka0]]&benchmarka3=[[benchmarka3]]" method="POST" onSubmit="if (!confirm('Really add pretask [[pretask.getId()]] from this supertask [[supertask.getId()]]?')) return false;">
+                  <input type="hidden" name="action" value="[[$DSupertaskAction::ADD_PRETASK_TO_SUPERTASK]]">
+                  <input type="hidden" name="supertaskId" value="[[supertask.getId()]]">
+                  <input type="hidden" name="pretaskId" value="[[pretask.getId()]]">
+                  <input type="hidden" name="csrf" value="[[csrf]]">
+                  <input type="hidden" name="benchmarka0" value="[[benchmarka0]]">
+                  <input type="hidden" name="benchmarka3" value="[[benchmarka3]]">
+                  <input type="submit" class='btn btn-danger' value="Add">
+                </form>
+              {{ENDIF}}
+            </td>
+          </tr>
+        {{ENDFOREACH}}
+      </tbody>
+      </table>
+    </div>
+  </div>
+
+  {{IF [[benchmarka0]] != 0 AND [[benchmarka3]] != 0}}
+    <input type=hidden id="benchmarka0" value="[[benchmarka0]]">
+    <input type=hidden id="benchmarka3" value="[[benchmarka3]]">
+
+    <!-- Parse attack command and compute runtime based on benchmark from form input value -->
+    <script src="static/optparse.1.1.1.js"></script>
+    <script src="static/optparse.hashtopolis.1.1.1.js"></script>
+    <script>
+        function calc_keyspace_size(cmd) {
+            // resetting the options
+            options = defaultOptions;
+            options.ruleFiles = [];
+            options.posArgs = [];
+            options.unrecognizedFlag = [];
+
+            // example cmd = "hashcat #HL# -a3 ?d?d?d?d"
+            // TODO: ensure the opt-parser works for -a3 instead of requiring a space as in '-a 3' to parse attackType
+            args = cmd.replace('hashcat', '');
+            args = args.replace(/(-a)(\d)(\s)/,"-a $2 "); // ensures that "-a3" becomes a valid attack mode: the opt-parser does not approve it (yet)
+            args = args.replace(/(-\d)(\S+)(\s)/,"$1 $2 "); // ensures that "-1?l?d" becomes a valid customCharset: the opt-parser does not approve it (yet)
+            args = args.replace(/\s+/g, ' '); // ensures that multiple consecutive spaces are reduced to a single space
+            args = args.trim();
+            args = args.split(/ |=/g);
+            parser.parse(args);
+            // console.log(options);
+
+            function customCharsetToOptions(mask) {
+                numA = (mask.match(/\?a/g) || []).length;
+                numD = (mask.match(/\?d/g) || []).length;
+                numL = (mask.match(/\?l/g) || []).length;
+                numU = (mask.match(/\?u/g) || []).length;
+                numS = (mask.match(/\?s/g) || []).length;
+                var charsetOptions = 95 * Math.min(1, numA);
+                charsetOptions = charsetOptions + 10 * Math.min(1, numD);
+                charsetOptions = charsetOptions + 26 * Math.min(1, numL);
+                charsetOptions = charsetOptions + 26 * Math.min(1, numU);
+                charsetOptions = charsetOptions + 33 * Math.min(1, numS);
+                // add single characters that are part of the custom charset
+                // TODO: we assume no duplicate single characters are present in the custom charset!
+                //       i.e. -1 abbc is considered to be a charset of 4 different characters in the calculation
+                charsetOptions = charsetOptions + mask.length - 2*numA - 2*numD - 2*numL -2*numU -2*numS;
+                // console.log("mask = " + mask + " this is " + charsetOptions+ " many options")
+                return charsetOptions;
+            }
+
+            function maskToKeyspace(mask) {
+                var keyspaceCustomMask = 1;
+                // The size of the custom charset equals the result of customCharsetToOptions.
+                // This number is multiplied by the number occurrences of the custom mask to get the size of the keyspace formed by the custom masks alone
+                if (options.customCharset1 !== "")
+                    {
+                        keyspaceCustomMask = keyspaceCustomMask * Math.pow(customCharsetToOptions(options.customCharset1), (mask.match(/\?1/g) || []).length);}
+                if (options.customCharset2 !== "")
+                    {
+                        keyspaceCustomMask = keyspaceCustomMask * Math.pow(customCharsetToOptions(options.customCharset2), (mask.match(/\?2/g) || []).length);}
+                if (options.customCharset3 !== "")
+                    {
+                        keyspaceCustomMask = keyspaceCustomMask * Math.pow(customCharsetToOptions(options.customCharset3), (mask.match(/\?3/g) || []).length);}
+                if (options.customCharset4 !== "")
+                    {
+                        keyspaceCustomMask = keyspaceCustomMask * Math.pow(customCharsetToOptions(options.customCharset4), (mask.match(/\?4/g) || []).length);}
+
+                var keyspaceRegularMask = 1;
+
+                // compute the keyspace size for the custom charsets separately, and multiply with the keyspace size formed by the regular mask part
+                keyspaceRegularMask = Math.pow(95, (mask.match(/\?a/g) || []).length);
+                keyspaceRegularMask = keyspaceRegularMask * Math.pow(10, (mask.match(/\?d/g) || []).length);
+                keyspaceRegularMask = keyspaceRegularMask * Math.pow(26, (mask.match(/\?l/g) || []).length);
+                keyspaceRegularMask = keyspaceRegularMask * Math.pow(26, (mask.match(/\?u/g) || []).length);
+                keyspaceRegularMask = keyspaceRegularMask * Math.pow(33, (mask.match(/\?s/g) || []).length);
+                // console.log("total keyspace: "+keyspaceRegularMask +" * "+ keyspaceCustomMask);
+
+                return keyspaceRegularMask * keyspaceCustomMask;
+            }
+
+            var keyspace;
+            if (options.attackType === 3) {
+                // compute keyspace for bruteforce attacks
+                for (var i = 0; i < options.posArgs.length; i++) {
+                    posArg = options.posArgs[i];
+                    if (posArg.includes("?")) {
+                        mask = posArg;
+                        keyspace = maskToKeyspace(mask);
+                        return [keyspace, options.attackType];
+                    }
+                }
+            }
+            return [null, options.attackType]
+        }
+    </script>
+    <script>
+        // compute keyspace size and runtime
+        var totalSecondsSupertask = 0;
+        var unknown_runtime_included = 0;
+        $(".taskInSuper").each(function (index) {
+            var keyspace_size;
+            // auxiliary keyspace is the keyspace formed by the product of the line counts of the files linked to a pretask
+            var auxiliaryKeyspace = $(this).find("td:nth-child(4)").text();
+            var keyspace_attackType_pair;
+            var seconds = null;
+            var attackCmd = $(this).find("td:nth-child(3)").text();
+            if (auxiliaryKeyspace != 1) {
+                // console.log("Attack command: " + attackCmd);
+                // it is not a bruteforce attack, and so we calculate the keyspace the product of the number of lines in the relevant files
+                keyspace_attackType_pair = calc_keyspace_size(attackCmd);
+                keyspace_size = auxiliaryKeyspace;
+            } else {
+                // console.log("Attack command: " + attackCmd);
+                keyspace_attackType_pair = calc_keyspace_size(attackCmd);
+                keyspace_size = keyspace_attackType_pair[0];
+            }
+
+            $(this).find("td:nth-child(5)").html(keyspace_size);
+
+            var benchmarka0 = $('#benchmarka0').val();
+            var benchmarka3 = $('#benchmarka3').val();
+
+
+            if (keyspace_attackType_pair[1] === 3) {
+                seconds = Math.floor(keyspace_size / benchmarka3);
+            }
+
+            if (keyspace_attackType_pair[1] === 0) {
+                seconds = Math.floor(keyspace_size / benchmarka0);
+            }
+
+            if (Number.isInteger(seconds)) {
+                totalSecondsSupertask = totalSecondsSupertask + seconds;
+                var days = Math.floor(seconds / (3600 * 24));
+                seconds -= days * 3600 * 24;
+                var hrs = Math.floor(seconds / 3600);
+                seconds -= hrs * 3600;
+                var mins = Math.floor(seconds / 60);
+                seconds -= mins * 60;
+
+                runtime = days + "d, " + hrs + "h, " + mins + "m, " + seconds + "s";
+            } else {
+                unknown_runtime_included = 1;
+                runtime = "Unknown";
+            }
+
+            // console.log("Benchmark a0: " + benchmarka0);
+            // console.log("Benchmark a3: " + benchmarka3);
+            // console.log("Runtime: " + runtime);
+            $(this).find("td:nth-child(6)").html(runtime);
+        });
+
+        // reduce total runtime to a human format
+        var seconds = totalSecondsSupertask;
+        var days = Math.floor(seconds / (3600 * 24));
+        seconds -= days * 3600 * 24;
+        var hrs = Math.floor(seconds / 3600);
+        seconds -= hrs * 3600;
+        var mins = Math.floor(seconds / 60);
+        seconds -= mins * 60;
+
+        totalRuntimeSupertask = days + "d, " + hrs + "h, " + mins + "m, " + seconds + "s";
+        if (unknown_runtime_included === 1) {
+            totalRuntimeSupertask = totalRuntimeSupertask + ", plus additional unknown runtime"
+        }
+
+        $(".runtimeOfSupertask").html(totalRuntimeSupertask)
+        // do not add to total runtime of supertask the runtime of those tasks that are not in the supertask
+        $(".taskNotInSuper").each(function (index) {
+            var keyspace_size;
+            var filesCountLinesProduct = $(this).find("td:nth-child(4)").text();
+            var keyspace_attackType_pair;
+            var seconds;
+            var attackCmd = $(this).find("td:nth-child(3)").text();
+            if (filesCountLinesProduct != 1) {
+                // it is not a bruteforce attack, and so we calculate the keyspace the product of the number of lines in the relevant files
+                keyspace_attackType_pair = calc_keyspace_size(attackCmd);
+                keyspace_size = filesCountLinesProduct;
+            } else {
+                // console.log("Attack command: " + attackCmd);
+
+                keyspace_attackType_pair = calc_keyspace_size(attackCmd);
+                keyspace_size = keyspace_attackType_pair[0];
+            }
+
+            $(this).find("td:nth-child(5)").html(keyspace_size);
+
+            var benchmarka0 = $('#benchmarka0').val();
+            var benchmarka3 = $('#benchmarka3').val();
+
+
+            if (keyspace_attackType_pair[1] === 3) {
+                seconds = Math.floor(keyspace_size / benchmarka3);
+            }
+
+            if (keyspace_attackType_pair[1] === 0) {
+                seconds = Math.floor(keyspace_size / benchmarka0);
+            }
+
+            if (Number.isInteger(seconds)) {
+                var days = Math.floor(seconds / (3600 * 24));
+                seconds -= days * 3600 * 24;
+                var hrs = Math.floor(seconds / 3600);
+                seconds -= hrs * 3600;
+                var mins = Math.floor(seconds / 60);
+                seconds -= mins * 60;
+
+                runtime = days + "d, " + hrs + "h, " + mins + "m, " + seconds + "s";
+            } else {
+                runtime = "Unknown";
+            }
+
+            // console.log("Benchmark: " + benchmark);
+            // console.log("Runtime: " + runtime);
+            $(this).find("td:nth-child(6)").html(runtime);
+        });
+    </script>
+  {{ENDIF}}
+
+  <!-- Create JTables from tables -->
+  <script type="text/javascript">
+      // make jtable
+      $(document).ready(function () {
+          $('#pretasksOfSupertasks').DataTable({
+              pageLength: 10,
+              "order": [ [0, 'asc'], [1, 'asc'] ],
+              "columnDefs": [
+                  { "visible": false, "searchable": false, "targets": [3]},
+                  { "orderable": true, "targets": [0, 1, 2, 4, 5, 6]}
+              ]
+          });
+      });
+      $(document).ready(function () {
+          $('td[rel=popover]').popover({
+              html: true,
+              trigger: 'hover',
+              container: 'body',
+              content: function () { return '<img style="width: 100%; height: 6px; padding: 0px;" src="' + $(this).data('img') + '">'; }
+          });
+      });
+  </script>
+  <script type="text/javascript">
+      // make jtable
+      $(document).ready(function () {
+          $('#remainingPretasks').DataTable({
+              pageLength: 10,
+              "order": [ [0, 'desc'], [1, 'asc'] ],
+              "columnDefs": [
+                  { "visible": false, "searchable": false, "targets": [3]},
+                  { "orderable": true, "targets": [0, 1, 2, 4, 5, 6]}
+              ]
+          });
+      });
+      $(document).ready(function () {
+          $('td[rel=popover]').popover({
+              html: true,
+              trigger: 'hover',
+              container: 'body',
+              content: function () { return '<img style="width: 100%; height: 6px; padding: 0px;" src="' + $(this).data('img') + '">'; }
+          });
+      });
+  </script>
 {{ENDIF}}
 {%TEMPLATE->struct/foot%}

--- a/src/templates/supertasks/index.template.html
+++ b/src/templates/supertasks/index.template.html
@@ -70,15 +70,15 @@
 											    {{ENDIF}}
 										    </td>
 										    <td class="right">
-											    {{IF [[accessControl.hasPermission([[$DAccessControl::CREATE_PRETASK_ACCESS]])]]}}
-												    <form style ='float: right;' action="pretasks.php?super=true" method="POST" onSubmit="if (!confirm('Really delete preconfigured task [[task.getId()]]?')) return false;">
-													    <input type="hidden" name="action" value="[[$DPretaskAction::DELETE_PRETASK]]">
-													    <input type="hidden" name="pretaskId" value="[[task.getId()]]">
-													    <input type="hidden" name="csrf" value="[[csrf]]">
-                              <button type="submit" class='btn btn-danger' data-toggle="tooltip" data-placement="top" title="Delete"><i class="fas fa-trash" aria-hidden="true"></i></button>
-												    </form>
-											    {{ENDIF}}
-										    </td>
+													{{IF [[accessControl.hasPermission([[$DAccessControl::MANAGE_SUPERTASK_ACCESS]])]]}}
+														<form style ='float: left;' action="supertasks.php" method="POST" onSubmit="if (!confirm('Really remove pretask [[task.getId()]] from this supertask [[supertask.getId()]]?')) return false;">
+															<input type="hidden" name="action" value="[[$DSupertaskAction::REMOVE_PRETASK_FROM_SUPERTASK]]">
+															<input type="hidden" name="supertaskId" value="[[supertask.getId()]]">
+															<input type="hidden" name="pretaskId" value="[[task.getId()]]">
+															<input type="hidden" name="csrf" value="[[csrf]]">
+															<input type="submit" class='btn btn-danger' value="Remove">
+														</form>
+													{{ENDIF}}
 									    </tr>
 								    {{ENDFOREACH}}
 							    </table>


### PR DESCRIPTION
Show estimated total runtime of a supertask, allowing the user to interactively come to the desired size of a supertask by adding or removing subtasks on the supertask detail page

Features:
* Allow adding and removing subtasks to supertask
* Save line count of dictionary files and rule files in database
* Parse hashcat commands to compute keyspace size. Gratefully uses the code submitted by shivanraptor in https://github.com/s3inlc/hashtopolis/pull/672 
Thank you, shivanraptor, for sharing your code with the community!
* Compute runtime per pretask of supertask, depending on benchmark values entered by the user
* Currently supports -a0 and -a3 hashcat attacks. Adds 'Unknown' to total runtime estimate when not every subtask runtime could be estimated
* Supports custom charsets for masks in -a3 attacks

Future work and additional remarks:
* _To do:_ add support for other hashcat attack modes
* _To do:_ make the hashcat command parser more robust towards syntax differences in hashcat commands. Note however, that some of these are already taken into account in this commit, such as the difference between "-a0" and "-a 0" for example, or when the command includes consecutive spaces
* _Note:_ the runtime estimate entirely depends on parsing hashcat commands. A pretask meant to be run by another cracker will result in an unknown runtime estimate.